### PR TITLE
Prepare baseline GSM8K GRPO Modal launch

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,9 @@
+if [ -d "$PWD/.venv" ]; then
+  export VIRTUAL_ENV="$PWD/.venv"
+  unset PYTHONHOME
+  PATH_add "$VIRTUAL_ENV/bin"
+fi
+
+if [ -f "$PWD/.env" ]; then
+  dotenv "$PWD/.env"
+fi

--- a/README.md
+++ b/README.md
@@ -55,16 +55,15 @@ uv tool run modal setup
 
 Launch training from your local checkout onto Modal:
 ```bash
-scripts/modal_train.sh \
-  --wandb-config.project curious \
-  --wandb-config.name modal-grpo-smoke \
-  --base-config.model-name Qwen/Qwen2.5-0.5B-Instruct \
-  --base-config.train-batch-size 8 \
-  --rl-config.group-size 16 \
-  --rl-config.kl-weight 0
+scripts/launch_baseline_gsm8k_grpo_modal.sh
 ```
 
-The Modal launcher defaults to `gpu=H100` and persists train logs, eval logs, checkpoints, Hugging Face cache, and W&B cache in the `curious-training-artifacts` Modal Volume. The wrapper forwards unknown flags to `curious.training`; use `--` only when you want to separate launcher options from training options:
+The prepared baseline uses `Qwen/Qwen3-0.6B` with SGLang rollout generation
+and FlashAttention-3 on one H100. The Modal launcher persists train logs, eval
+logs, checkpoints, Hugging Face cache, and W&B cache in the
+`curious-training-artifacts` Modal Volume. The wrapper forwards unknown flags to
+`curious.training`; use `--` only when you want to separate launcher options
+from training options:
 ```bash
 scripts/modal_train.sh --gpu A100-80GB --timeout 86400 -- \
   --base-config.checkpoint-interval 20

--- a/curious/config.py
+++ b/curious/config.py
@@ -10,6 +10,11 @@ class WandbConfig:
     A dataclass for storing the wandb configuration.
     """
 
+    entity: str = "autocurriculum"
+    """
+    The entity to use for the wandb.
+    """
+
     project: str = "curious"
     """
     The project to use for the wandb.
@@ -31,7 +36,7 @@ class BaseConfig:
     A dataclass for storing the evaluation configuration.
     """
     # Model and dataset
-    model_name: str = "Qwen/Qwen2-0.5B-Instruct"
+    model_name: str = "Qwen/Qwen3-0.6B"
     """
     The name of the model to use for the training.
     """
@@ -95,19 +100,29 @@ class BaseConfig:
     The interval to use for the checkpoint and to evaluate the model.
     """
 
-    eval_interval: int = 50
+    eval_interval: int = 10
     """
     The interval to use for the evaluation.
     """
 
-    train_text_log_interval: int = 500
+    train_text_log_interval: int = 10
     """
     The interval to use for the train text log.
     """
 
-    eval_text_log_interval: int = 500
+    train_entropy_log_interval: int = 1
+    """
+    The interval to compute and log train action entropy. Set to 0 or lower to disable.
+    """
+
+    eval_text_log_interval: int = 10
     """
     The interval to use for the eval text log.
+    """
+
+    completion_log_sample_size: int = 8
+    """
+    The maximum number of train/eval sample completions to log at each text log interval.
     """
 
     return_entropy: bool = False
@@ -115,7 +130,7 @@ class BaseConfig:
     Whether to return the entropy of the tokens.
     """
 
-    deepspeed_config: str = None
+    deepspeed_config: Optional[str] = None
     """
     The path to the deepspeed config file.
     """
@@ -170,6 +185,71 @@ class SamplingConfig:
     system_prompt: str = "deepseek_system_prompt"
     """
     The system prompt to use for the sampling.
+    """
+
+    generation_backend: str = "hf"
+    """
+    The generation backend to use for rollouts. One of: hf, sglang.
+    """
+
+    sglang_attention_backend: str = "fa3"
+    """
+    The attention backend to use for SGLang rollout generation.
+    """
+
+    sglang_mem_fraction_static: float = 0.40
+    """
+    The static memory fraction reserved by SGLang on the H100.
+    """
+
+    sglang_host: str = "127.0.0.1"
+    """
+    The host for the local SGLang server.
+    """
+
+    sglang_port: int = 30000
+    """
+    The port for the local SGLang server.
+    """
+
+    sglang_log_level: str = "warning"
+    """
+    The SGLang server log level.
+    """
+
+    sglang_max_running_requests: Optional[int] = None
+    """
+    The optional maximum number of running requests for SGLang.
+    """
+
+    sglang_chunked_prefill_size: Optional[int] = None
+    """
+    The optional chunked prefill size for SGLang.
+    """
+
+    sglang_request_batch_size: Optional[int] = None
+    """
+    The optional number of prompt instances to send per SGLang /generate request.
+    """
+
+    sglang_startup_timeout: int = 600
+    """
+    The number of seconds to wait for SGLang startup.
+    """
+
+    sglang_weight_sync: str = "disk"
+    """
+    The SGLang policy weight synchronization method. Currently only disk is supported.
+    """
+
+    sglang_weight_sync_dir: str = "sglang_weight_sync"
+    """
+    The local directory used for disk-based SGLang weight sync.
+    """
+
+    sglang_weight_sync_interval: int = 1
+    """
+    The number of completed training batches between SGLang policy weight syncs.
     """
 
 @dataclass

--- a/curious/evaluate.py
+++ b/curious/evaluate.py
@@ -9,7 +9,12 @@ from torch.utils.data import DataLoader
 from transformers import PreTrainedTokenizer, PreTrainedModel
 
 from curious.data import GSM8KDataset
-from curious.utils.utils import LOGGING_TEMPLATE, load_model_tokenizer
+from curious.utils.utils import (
+    build_completion_sample_rows,
+    format_completion_sample_rows,
+    load_model_tokenizer,
+    log_completion_sample_table,
+)
 from curious.sampling import compute_rewards
 from curious.reward.rule.gsm8k import GSM8KRewardModel
 from curious.prompt import *
@@ -141,7 +146,12 @@ def evaluate(
     infos: List[Dict[str, str]] = []
     solved_masks: List[int] = []
     num_words_in_completions: List[int] = []
-    for _, batch_inputs in enumerate(dataloader):
+    completion_sample_rows: List[Dict[str, Any]] = []
+    should_log_completion_samples = (
+        config.base_config.eval_text_log_interval > 0
+        and batch_idx % config.base_config.eval_text_log_interval == 0
+    )
+    for eval_batch_idx, batch_inputs in enumerate(dataloader):
         
         # Get the questions and answers
         questions = batch_inputs["question"]
@@ -180,6 +190,7 @@ def evaluate(
         batch_mean_outcome_returns: float = np.array([x["outcome_reward"] for x in batch_infos]).mean()
         batch_mean_length_penalty: float = np.array([x["length_penalty"] for x in batch_infos]).mean()
 
+        sample_offset = len(rewards)
         rewards.extend(batch_rewards.reshape(-1).tolist())
         infos.extend(batch_infos)
         solved_masks.extend(batch_solved_masks.reshape(-1).tolist())
@@ -196,33 +207,28 @@ def evaluate(
                 "eval/batch_mean_num_words_in_completions": np.array(batch_num_words_in_completions).mean(),
                 "eval/batch_max_num_words_in_completions": np.array(batch_num_words_in_completions).max(),
                 "eval/batch_min_num_words_in_completions": np.array(batch_num_words_in_completions).min(),
+                "eval/batch_idx": eval_batch_idx,
+                "num_batches_visited": batch_idx,
             }
         )
 
-        ## Save the text on disk if the batch index is a multiple of the eval text log interval
-        if config.base_config.eval_text_log_interval > 0:
-            if batch_idx % config.base_config.eval_text_log_interval == 0:
-                # Log the text to logger
-                text_to_log = ""
-                for question, answer, completion, reward, info in zip(
-                    questions,
-                    oracle_answers,
-                    completions,
-                    batch_rewards.reshape(-1),
-                    batch_infos,
-                ):
-                    text_to_log += LOGGING_TEMPLATE.format(
-                        question=question,
-                        answer=answer,
-                        completion=completion,
-                        reward=reward,
-                        info=info,
-                    )
-
-                file_name = f"log_{batch_idx}.txt"
-                with open(os.path.join(out_dir, file_name), "a") as f:
-                    f.write(text_to_log)
-                f.close()
+        if should_log_completion_samples:
+            remaining_samples = (
+                config.base_config.completion_log_sample_size - len(completion_sample_rows)
+            )
+            completion_sample_rows.extend(
+                build_completion_sample_rows(
+                    phase="eval",
+                    batch_idx=batch_idx,
+                    questions=questions,
+                    answers=oracle_answers,
+                    completions=completions,
+                    rewards=batch_rewards.reshape(-1).tolist(),
+                    infos=batch_infos,
+                    max_samples=remaining_samples,
+                    sample_offset=sample_offset,
+                )
+            )
         # --------------------- Logging End ---------------------
         
         # free up memory
@@ -237,6 +243,16 @@ def evaluate(
         gc.collect()
         torch.cuda.empty_cache()
 
+    if should_log_completion_samples:
+        file_name = f"log_{batch_idx}.txt"
+        with open(os.path.join(out_dir, file_name), "a") as f:
+            f.write(format_completion_sample_rows(completion_sample_rows))
+        log_completion_sample_table(
+            logger=logger,
+            key="eval/completion_samples",
+            rows=completion_sample_rows,
+        )
+
     # Log the mean rewards and the mean solved rate
     mean_pass1 = np.array(solved_masks).mean()
     mean_rewards = np.array(rewards).mean()
@@ -246,6 +262,7 @@ def evaluate(
             "eval/mean_rewards": mean_rewards,
             "eval/mean_solved_rate": mean_pass1,
             "eval/mean_num_words_in_completions": mean_num_words_in_completions,
+            "num_batches_visited": batch_idx,
         }
     )
     print(f"Batch {batch_idx} #### Mean Eval pass@1: {mean_pass1}")
@@ -268,11 +285,15 @@ if __name__ == "__main__":
 
     # Initialize the wandb
     wandb.init(
+        entity=config.wandb_config.entity,
         project=config.wandb_config.project,
         name=config.wandb_config.name,
+        group=config.wandb_config.group,
         config=config,
     )
     logger = wandb.log
+    wandb.define_metric("num_batches_visited")
+    wandb.define_metric("eval/*", step_metric="num_batches_visited")
 
     # Load the model
     model, tokenizer = load_model_tokenizer(

--- a/curious/modal_train.py
+++ b/curious/modal_train.py
@@ -30,12 +30,8 @@ training_image = (
     .apt_install(
         "build-essential",
         "git",
-        "libopenmpi-dev",
-        "openmpi-bin",
     )
     .uv_sync(uv_version="0.6.12")
-    .add_local_python_source("curious")
-    .add_local_file("deepspeed_config.json", "/root/deepspeed_config.json")
     .workdir("/root")
     .env(
         {
@@ -47,6 +43,7 @@ training_image = (
             "WANDB_CACHE_DIR": f"{ARTIFACTS_DIR}/wandb_cache",
         }
     )
+    .add_local_python_source("curious")
 )
 
 
@@ -68,10 +65,32 @@ def _with_default_artifact_paths(args: list[str]) -> list[str]:
     return resolved_args
 
 
+def _dotenv_values(dotenv_path: str) -> dict[str, str]:
+    path = Path(dotenv_path)
+    if not path.exists():
+        return {}
+
+    values: dict[str, str] = {}
+    for raw_line in path.read_text().splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        value = value.strip()
+        if value and value[0] in {"'", '"'} and value[-1:] == value[0]:
+            value = value[1:-1]
+        if key:
+            values[key] = value
+    return values
+
+
 def _local_secrets(dotenv_path: str | None, include_env_secret: bool, secret_names: list[str]) -> list[modal.Secret]:
     secrets: list[modal.Secret] = []
     if dotenv_path is not None:
-        secrets.append(modal.Secret.from_dotenv(dotenv_path))
+        dotenv_secret = _dotenv_values(dotenv_path)
+        if dotenv_secret:
+            secrets.append(modal.Secret.from_dict(dotenv_secret))
 
     if include_env_secret:
         env_secret = {

--- a/curious/sampling/sampling.py
+++ b/curious/sampling/sampling.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Tuple
+from typing import List, Dict, Tuple, Protocol
 import gc
 
 import torch
@@ -11,6 +11,17 @@ from accelerate.utils import set_seed
 
 from curious.reward.rule.gsm8k import GSM8KRewardModel
 from curious.utils.utils import release_memory, move_paddings_to_right
+
+
+class RolloutGenerationBackend(Protocol):
+    def sample_responses(
+        self,
+        batch_inputs: Dict[str, torch.Tensor],
+        generation_config: GenerationConfig,
+        seed: int = 42,
+    ) -> Dict[str, torch.Tensor]:
+        ...
+
 
 def linear_temperature_annealing(current_step: int, total_steps: int, start_temp: float, end_temp: float) -> float:
     """
@@ -154,6 +165,7 @@ def rollout(
     seed: int = 42,
     normalize_centered_returns: bool = False,
     use_rloo_scalar: bool = False,
+    generation_backend: RolloutGenerationBackend | None = None,
 ) -> Dict[str, torch.Tensor]:
     """
     Performs a rollout of the model.
@@ -174,14 +186,23 @@ def rollout(
     # get the batch size
     oracle_answers = batch_inputs["oracle_answer"]
     
-    # get the sequence ids from huggingface
-    sampled_responses = sample_responses_hf(
-        model,
-        tokenizer,
-        batch_inputs,
-        generation_config,
-        seed=seed,
-    )
+    if generation_backend is None:
+        sampled_responses = sample_responses_hf(
+            model,
+            tokenizer,
+            batch_inputs,
+            generation_config,
+            seed=seed,
+        )
+    else:
+        sampled_responses = generation_backend.sample_responses(
+            batch_inputs=batch_inputs,
+            generation_config=generation_config,
+            seed=seed,
+        )
+
+    sampled_responses["sequence_ids"] = sampled_responses["sequence_ids"].to(model.device)
+    sampled_responses["action_mask"] = sampled_responses["action_mask"].to(model.device)
     
     # get the rewards
     rewards_out = compute_rewards(
@@ -216,7 +237,6 @@ def rollout(
 
     return rewards_out
 
-@torch.compile(dynamic=True)
 def compute_group_advantages(
     returns: torch.Tensor, 
     eps: float = 1e-8, 
@@ -244,7 +264,6 @@ def compute_group_advantages(
 
     return centered_returns    
 
-@torch.compile(dynamic=True)
 def _sequence_log_probs_from_logits(
     logits: torch.Tensor, 
     output_ids: torch.Tensor,
@@ -278,7 +297,6 @@ def _sequence_log_probs_from_logits(
     else:
         return log_probs, None
 
-@torch.compile(dynamic=True)
 def sequences_log_probs(
     model: PreTrainedModel,
     sequence_ids: torch.Tensor,

--- a/curious/sampling/sglang_backend.py
+++ b/curious/sampling/sglang_backend.py
@@ -1,0 +1,292 @@
+import atexit
+import json
+import shutil
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+import torch
+from transformers import GenerationConfig, PreTrainedModel, PreTrainedTokenizer
+
+from curious.utils.utils import release_memory
+
+
+class SGLangGenerationBackend:
+    def __init__(
+        self,
+        model_path: str,
+        tokenizer: PreTrainedTokenizer,
+        host: str,
+        port: int,
+        attention_backend: str,
+        mem_fraction_static: float,
+        log_level: str,
+        startup_timeout: int,
+        weight_sync_dir: str,
+        max_running_requests: int | None = None,
+        chunked_prefill_size: int | None = None,
+        request_batch_size: int | None = None,
+    ) -> None:
+        self.model_path = model_path
+        self.tokenizer = tokenizer
+        self.host = host
+        self.port = port
+        self.base_url = f"http://{host}:{port}"
+        self.weight_sync_dir = Path(weight_sync_dir)
+        self.weight_sync_dir.mkdir(parents=True, exist_ok=True)
+        self._last_synced_path: Path | None = None
+        self.request_batch_size = request_batch_size
+
+        command = [
+            sys.executable,
+            "-m",
+            "sglang.launch_server",
+            "--model-path",
+            model_path,
+            "--host",
+            host,
+            "--port",
+            str(port),
+            "--attention-backend",
+            attention_backend,
+            "--mem-fraction-static",
+            str(mem_fraction_static),
+            "--log-level",
+            log_level,
+        ]
+        if max_running_requests is not None:
+            command.extend(["--max-running-requests", str(max_running_requests)])
+        if chunked_prefill_size is not None:
+            command.extend(["--chunked-prefill-size", str(chunked_prefill_size)])
+
+        print("Starting SGLang rollout server:", " ".join(command), flush=True)
+        self.process = subprocess.Popen(command)
+        atexit.register(self.close)
+        self._wait_until_ready(startup_timeout)
+
+    def _wait_until_ready(self, timeout_seconds: int) -> None:
+        deadline = time.time() + timeout_seconds
+        last_error = ""
+        while time.time() < deadline:
+            if self.process.poll() is not None:
+                raise RuntimeError(f"SGLang server exited early with code {self.process.returncode}: {last_error}")
+            try:
+                self._request("GET", "/health")
+                return
+            except Exception as exc:
+                last_error = str(exc)
+                time.sleep(2)
+        raise TimeoutError(f"SGLang server did not become healthy within {timeout_seconds}s: {last_error}")
+
+    def _request(self, method: str, path: str, payload: dict[str, Any] | None = None) -> Any:
+        data = None
+        headers = {}
+        if payload is not None:
+            data = json.dumps(payload).encode("utf-8")
+            headers["Content-Type"] = "application/json"
+        request = urllib.request.Request(
+            f"{self.base_url}{path}",
+            data=data,
+            headers=headers,
+            method=method,
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=600) as response:
+                body = response.read().decode("utf-8")
+        except urllib.error.HTTPError as exc:
+            body = exc.read().decode("utf-8", errors="replace")
+            raise RuntimeError(f"SGLang {method} {path} failed with HTTP {exc.code}: {body}") from exc
+        if not body:
+            return None
+        return json.loads(body)
+
+    def sample_responses(
+        self,
+        batch_inputs: dict[str, torch.Tensor],
+        generation_config: GenerationConfig,
+        seed: int = 42,
+    ) -> dict[str, torch.Tensor]:
+        input_ids = batch_inputs["input_ids"]
+        attention_mask = batch_inputs["attention_mask"]
+        prompt_ids: list[list[int]] = []
+        for ids, mask in zip(input_ids, attention_mask):
+            trimmed_ids = ids[mask.bool()].tolist()
+            for _ in range(generation_config.num_return_sequences):
+                prompt_ids.append(trimmed_ids)
+
+        stop_token_ids = []
+        if self.tokenizer.eos_token_id is not None:
+            stop_token_ids.append(self.tokenizer.eos_token_id)
+
+        sampling_params = {
+            "max_new_tokens": generation_config.max_new_tokens,
+            "temperature": generation_config.temperature,
+            "top_p": generation_config.top_p,
+            "top_k": generation_config.top_k,
+            "repetition_penalty": generation_config.repetition_penalty,
+            "skip_special_tokens": True,
+        }
+        if stop_token_ids:
+            sampling_params["stop_token_ids"] = stop_token_ids
+
+        del seed
+        response_items = []
+        request_batch_size = getattr(self, "request_batch_size", None) or len(prompt_ids)
+        if request_batch_size <= 0:
+            raise ValueError("request_batch_size must be positive when set")
+
+        for start in range(0, len(prompt_ids), request_batch_size):
+            chunk_prompt_ids = prompt_ids[start:start + request_batch_size]
+            payload = {
+                "input_ids": chunk_prompt_ids,
+                "sampling_params": sampling_params,
+            }
+            response = self._request("POST", "/generate", payload)
+            chunk_items = response if isinstance(response, list) else [response]
+            if len(chunk_items) != len(chunk_prompt_ids):
+                raise RuntimeError(
+                    f"SGLang returned {len(chunk_items)} responses for {len(chunk_prompt_ids)} prompts"
+                )
+            response_items.extend(chunk_items)
+
+        if len(response_items) != len(prompt_ids):
+            raise RuntimeError(f"SGLang returned {len(response_items)} responses for {len(prompt_ids)} prompts")
+
+        output_token_ids: list[list[int]] = []
+        completions: list[str] = []
+        for item in response_items:
+            text = _extract_text(item)
+            output_ids = _extract_output_token_ids(item)
+            if output_ids is None:
+                output_ids = self.tokenizer.encode(text, add_special_tokens=False)
+            output_token_ids.append(output_ids)
+            completions.append(text)
+
+        return build_sampled_response_tensors(
+            tokenizer=self.tokenizer,
+            prompt_ids=prompt_ids,
+            output_token_ids=output_token_ids,
+            completions=completions,
+            device=batch_inputs["input_ids"].device,
+        )
+
+    def sync_weights_from_model(
+        self,
+        model: PreTrainedModel,
+        tokenizer: PreTrainedTokenizer,
+        step: int,
+    ) -> None:
+        model_to_save = model.module if hasattr(model, "module") else model
+        target_path = self.weight_sync_dir / f"step_{step:08d}"
+        tmp_path = self.weight_sync_dir / f".step_{step:08d}.tmp"
+        if tmp_path.exists():
+            shutil.rmtree(tmp_path)
+        tmp_path.mkdir(parents=True)
+
+        model_to_save.save_pretrained(tmp_path, safe_serialization=True)
+        tokenizer.save_pretrained(tmp_path)
+        if target_path.exists():
+            shutil.rmtree(target_path)
+        tmp_path.rename(target_path)
+
+        response = self._request(
+            "POST",
+            "/update_weights_from_disk",
+            {"model_path": str(target_path)},
+        )
+        if not isinstance(response, dict) or response.get("success") is not True:
+            raise RuntimeError(f"SGLang weight sync failed: {response}")
+
+        previous_path = self._last_synced_path
+        self._last_synced_path = target_path
+        if previous_path is not None and previous_path != target_path and previous_path.exists():
+            shutil.rmtree(previous_path)
+
+        release_memory([])
+
+    def close(self) -> None:
+        process = getattr(self, "process", None)
+        if process is None or process.poll() is not None:
+            return
+        process.terminate()
+        try:
+            process.wait(timeout=20)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=20)
+
+
+def build_sampled_response_tensors(
+    tokenizer: PreTrainedTokenizer,
+    prompt_ids: list[list[int]],
+    output_token_ids: list[list[int]],
+    completions: list[str],
+    device: torch.device,
+) -> dict[str, torch.Tensor]:
+    if len(prompt_ids) != len(output_token_ids):
+        raise ValueError("prompt_ids and output_token_ids must have the same length")
+
+    pad_token_id = tokenizer.pad_token_id
+    full_sequences = [prompt + output for prompt, output in zip(prompt_ids, output_token_ids)]
+    max_length = max(len(sequence) for sequence in full_sequences)
+    sequence_ids = torch.full(
+        (len(full_sequences), max_length),
+        fill_value=pad_token_id,
+        dtype=torch.long,
+        device=device,
+    )
+    action_mask = torch.zeros(
+        (len(full_sequences), max_length - 1),
+        dtype=torch.bool,
+        device=device,
+    )
+    for row_idx, (prompt, output, sequence) in enumerate(zip(prompt_ids, output_token_ids, full_sequences)):
+        sequence_length = len(sequence)
+        sequence_ids[row_idx, :sequence_length] = torch.tensor(sequence, dtype=torch.long, device=device)
+        if output:
+            start = max(len(prompt) - 1, 0)
+            action_mask[row_idx, start:start + len(output)] = True
+
+    return {
+        "num_samples": len(full_sequences),
+        "input_ids": sequence_ids,
+        "sequence_ids": sequence_ids,
+        "action_mask": action_mask,
+        "completions": completions,
+    }
+
+
+def _extract_text(item: Any) -> str:
+    if not isinstance(item, dict):
+        return ""
+    text = item.get("text")
+    if isinstance(text, str):
+        return text
+    return ""
+
+
+def _extract_output_token_ids(item: Any) -> list[int] | None:
+    if not isinstance(item, dict):
+        return None
+
+    for key in ("output_ids", "output_token_ids", "token_ids"):
+        value = item.get(key)
+        if _is_int_list(value):
+            return list(value)
+
+    meta_info = item.get("meta_info")
+    if isinstance(meta_info, dict):
+        for key in ("output_ids", "output_token_ids", "token_ids"):
+            value = meta_info.get(key)
+            if _is_int_list(value):
+                return list(value)
+
+    return None
+
+
+def _is_int_list(value: Any) -> bool:
+    return isinstance(value, list) and all(isinstance(token_id, int) for token_id in value)

--- a/curious/train/train_rl.py
+++ b/curious/train/train_rl.py
@@ -194,15 +194,22 @@ def train(
             action_mask: torch.Tensor = rollout_out["action_mask"]
             completions:List[str] = rollout_out["completions"]
         
+            entropy_interval = args.base_config.train_entropy_log_interval
+            should_log_entropy = entropy_interval > 0 and batch_idx % entropy_interval == 0
+
             attention_mask: torch.Tensor = sequence_ids != pad_token_id # (num_samples * group_size, seq_len)
             log_probs, entropy = sequences_log_probs(
                 model=model,
                 sequence_ids=sequence_ids,
                 attention_mask=attention_mask,
-                return_entropy=True,
+                return_entropy=should_log_entropy,
                 logits_minibatch_size=args.rl_config.logits_minibatch_size,
             ) # (num_samples * group_size, seq_len-1)
-            action_entropy = masked_mean(entropy, action_mask, dim=None)
+            action_entropy = (
+                masked_mean(entropy, action_mask, dim=None)
+                if should_log_entropy and entropy is not None
+                else None
+            )
 
             kl, log_probs_ref, token_clip_high = None, None, None
             ad_cispo_stats: ADCispoStats | None = None
@@ -262,6 +269,7 @@ def train(
             log_probs_ref,
             token_clip_high,
             log_probs,
+            entropy,
             attention_mask,
             sequence_ids,
             action_mask,
@@ -273,25 +281,25 @@ def train(
 
         ### ----- Logging phase START ----- ###
         # log the stats to wandb 
-        logger(
-            {
-                "train/mean_batch_returns": batch_mean_returns,
-                "train/mean_batch_solved_rate": batch_mean_solved_rate,
+        log_payload = {
+            "train/mean_batch_returns": batch_mean_returns,
+            "train/mean_batch_solved_rate": batch_mean_solved_rate,
 
-                "train/mean_num_words_in_completions": batch_mean_num_words_in_completions,
-                "train/max_num_words_in_completions": batch_max_num_words_in_completions,
-                "train/min_num_words_in_completions": batch_min_num_words_in_completions,
+            "train/mean_num_words_in_completions": batch_mean_num_words_in_completions,
+            "train/max_num_words_in_completions": batch_max_num_words_in_completions,
+            "train/min_num_words_in_completions": batch_min_num_words_in_completions,
 
-                "train/mean_batch_format_returns": batch_mean_format_returns,
-                "train/mean_batch_outcome_returns": batch_mean_outcome_returns,
-                "train/mean_batch_length_penalty": batch_mean_length_penalty,
-                
-                "train/lr": lr_scheduler.get_lr()[0],
-                "train/mean_action_entropy": action_entropy.item(),
-                
-                "num_batches_visited": batch_idx,
-            }
-        )
+            "train/mean_batch_format_returns": batch_mean_format_returns,
+            "train/mean_batch_outcome_returns": batch_mean_outcome_returns,
+            "train/mean_batch_length_penalty": batch_mean_length_penalty,
+
+            "train/lr": lr_scheduler.get_lr()[0],
+            "num_batches_visited": batch_idx,
+        }
+        if action_entropy is not None:
+            log_payload["train/mean_action_entropy"] = action_entropy.item()
+
+        logger(log_payload)
         if ad_cispo_stats is not None:
             logger(
                 {
@@ -352,7 +360,7 @@ def train(
             shuffle=True, #if args.rl_config.use_token_level_loss else False,
             drop_last=False,
             collate_fn=join_experience_batch,
-            num_workers=args.base_config.num_workers,
+            num_workers=0,
         )
 
         model.train()
@@ -370,6 +378,7 @@ def train(
                     return_entropy=False,
                     logits_minibatch_size=args.rl_config.logits_minibatch_size,
                 )
+                kl_weight_used = objective.kl_weight if args.rl_config.kl_weight > 0 else 0.0
                 loss, mean_kl, mean_actor_loss = objective(log_probs=log_probs, experience=exp)
                 
                 del log_probs
@@ -391,18 +400,24 @@ def train(
                 mean_loss = loss.detach().cpu().item()
                 mean_kl = mean_kl.cpu().item()
                 mean_actor_loss = mean_actor_loss.cpu().item()
+                mean_kl_loss = mean_loss - mean_actor_loss
                 
+                kl_weight_next = kl_weight_used
                 if args.rl_config.kl_weight > 0:
                     kl_controller.update(mean_kl, args.rl_config.mini_batch_size)
                     objective.kl_weight = kl_controller.value
+                    kl_weight_next = kl_controller.value
                 
                 logger(
                     {
                         "train/grad_norm": grad_norm,
                         "train/loss": mean_loss,
                         "train/actor_loss": mean_actor_loss,
+                        "train/kl_loss": mean_kl_loss,
                         "train/mean_kl": mean_kl, 
-                        "train/kl_weight": kl_controller.value if args.rl_config.kl_weight > 0 else 0.0,
+                        "train/kl_weight": kl_weight_used,
+                        "train/kl_weight_used": kl_weight_used,
+                        "train/kl_weight_next": kl_weight_next,
                     }
                 )
 
@@ -412,6 +427,9 @@ def train(
                     mean_loss,
                     mean_kl,
                     mean_actor_loss,
+                    mean_kl_loss,
+                    kl_weight_used,
+                    kl_weight_next,
                 )
                 gc.collect()
                 torch.cuda.empty_cache()
@@ -526,6 +544,7 @@ if __name__ == "__main__":
         config=args,
     )
     wandb.define_metric("num_batches_visited")
+    wandb.define_metric("train/*", step_metric="num_batches_visited")
     wandb.define_metric("train/mean_batch_returns", step_metric="num_batches_visited")
     wandb.define_metric("train/mean_batch_solved_rate", step_metric="num_batches_visited")
     wandb.define_metric("train/max_input_length", step_metric="num_batches_visited")

--- a/curious/train/trainer.py
+++ b/curious/train/trainer.py
@@ -1,7 +1,13 @@
 from typing import Dict, List, Any, Tuple
 
 from pathlib import Path
-from curious.utils.utils import release_memory, LOGGING_TEMPLATE
+from curious.evaluate import evaluate
+from curious.utils.utils import (
+    build_completion_sample_rows,
+    format_completion_sample_rows,
+    log_completion_sample_table,
+    release_memory,
+)
 from curious.replay.experience import Experience, ReplayBuffer, join_experience_batch
 from curious.train.training_setup import TrainingSetup, TrainState
 from curious.sampling.sampling import rollout, sequences_log_probs
@@ -39,11 +45,30 @@ class PolicyGradientTrainer:
         self.logger = lambda x: print(x)
 
     def train(self, train_state: TrainState) -> Tuple[TrainState, ReplayBuffer]:
+        evaluate(
+            config=self.training_setup["eval_config"],
+            model=train_state["model"],
+            tokenizer=self.tokenizer,
+            logger=self.logger,
+            batch_idx=0,
+        )
+
         for epoch_idx in range(self.num_epochs):
             print(f"Epoch {epoch_idx} of {self.num_epochs}")
             for batch_idx, batch_inputs in enumerate(self.rollout_data_loader):
                 replay_buffer = self.collect_trajectories(train_state, batch_inputs, batch_idx)
-                train_state = self.update_policy(train_state, replay_buffer, batch_idx + 1)
+                completed_batches = batch_idx + 1
+                train_state = self.update_policy(train_state, replay_buffer, completed_batches)
+
+                eval_interval = self.base_config.eval_interval
+                if eval_interval > 0 and completed_batches % eval_interval == 0:
+                    evaluate(
+                        config=self.training_setup["eval_config"],
+                        model=train_state["model"],
+                        tokenizer=self.tokenizer,
+                        logger=self.logger,
+                        batch_idx=completed_batches,
+                    )
         
         return train_state, replay_buffer
     
@@ -72,6 +97,7 @@ class PolicyGradientTrainer:
             seed=train_state["seed"],
             normalize_centered_returns=self.training_setup["rl_config"].normalize_centered_returns,
             use_rloo_scalar=self.training_setup["rl_config"].use_rloo_scalar,
+            generation_backend=self.training_setup.get("generation_backend"),
         )
     
         returns: torch.Tensor = rollout_out["returns"].reshape(-1)
@@ -90,17 +116,21 @@ class PolicyGradientTrainer:
         completions:List[str] = rollout_out["completions"]
         stats["completions"] = completions
         
+        entropy_interval = self.base_config.train_entropy_log_interval
+        should_log_entropy = entropy_interval > 0 and batch_indx % entropy_interval == 0
+
         # (num_samples * group_size, seq_len-1)
         log_probs, entropy = sequences_log_probs(
             model=model,
             sequence_ids=sequence_ids,
             attention_mask=attention_mask,
-            return_entropy=True,
+            return_entropy=should_log_entropy,
             logits_minibatch_size=self.training_setup["rl_config"].logits_minibatch_size,
         ) 
 
-        mean_action_entropy = masked_mean(entropy, action_mask, dim=None)
-        stats["mean_action_entropy"] = mean_action_entropy
+        if should_log_entropy and entropy is not None:
+            mean_action_entropy = masked_mean(entropy, action_mask, dim=None)
+            stats["mean_action_entropy"] = mean_action_entropy
 
         kl, log_probs_ref, token_clip_high = None, None, None
         if self.training_setup["rl_config"].use_ad_cispo:
@@ -165,6 +195,7 @@ class PolicyGradientTrainer:
                 log_probs_ref,
                 token_clip_high,
                 log_probs,
+                entropy,
                 attention_mask,
                 sequence_ids,
                 action_mask,
@@ -187,9 +218,15 @@ class PolicyGradientTrainer:
             shuffle= False,
             drop_last=False,
             collate_fn=join_experience_batch,
-            num_workers=self.base_config.num_workers,
+            num_workers=0,
         )
 
+        model.train()
+        model.gradient_checkpointing_enable()
+        if hasattr(model, "config"):
+            model.config.use_cache = False
+
+        did_update = False
         for _ in range(self.rl_config.epochs_per_step):
             for experience in experience_sampler:
                 experience: Experience
@@ -203,6 +240,7 @@ class PolicyGradientTrainer:
                     return_entropy=False,
                     logits_minibatch_size=self.rl_config.logits_minibatch_size,
                 )
+                kl_weight_used = self.actor_loss.kl_weight if self.rl_config.kl_weight > 0 else 0.0
                 loss, mean_kl, mean_actor_loss = self.actor_loss(
                     log_probs=log_probs, 
                     experience=experience
@@ -219,21 +257,28 @@ class PolicyGradientTrainer:
                     max_norm=self.rl_config.max_grad_norm,
                 )
                 optimizer.step()
+                did_update = True
 
                 mean_loss = loss.detach().cpu().item()
                 mean_kl = mean_kl.detach().cpu().item()
                 mean_actor_loss = mean_actor_loss.detach().cpu().item()
+                mean_kl_loss = mean_loss - mean_actor_loss
 
+                kl_weight_next = kl_weight_used
                 if self.rl_config.kl_weight > 0:
                     kl_controller.update(mean_kl, self.rl_config.mini_batch_size)
                     self.actor_loss.kl_weight = kl_controller.value
+                    kl_weight_next = kl_controller.value
 
                 self.logger(
                     {
                         "train/loss": mean_loss,
                         "train/mean_kl": mean_kl,
                         "train/actor_loss": mean_actor_loss,
-                        "train/kl_weight": kl_controller.value if self.rl_config.kl_weight > 0 else 0.0,
+                        "train/kl_loss": mean_kl_loss,
+                        "train/kl_weight": kl_weight_used,
+                        "train/kl_weight_used": kl_weight_used,
+                        "train/kl_weight_next": kl_weight_next,
                         "train/grad_norm": grad_norm,
                         "num_batches_visited": batch_idx,
                     }
@@ -246,6 +291,7 @@ class PolicyGradientTrainer:
                         loss,
                         mean_kl,
                         mean_actor_loss,
+                        mean_kl_loss,
                     ]
                 )
 
@@ -259,6 +305,11 @@ class PolicyGradientTrainer:
         ):
             train_state["reference_model"].load_state_dict(model.state_dict())
             train_state["reference_model"].eval()
+
+        generation_backend = self.training_setup.get("generation_backend")
+        sync_interval = self.training_setup["sampling_config"].sglang_weight_sync_interval
+        if did_update and generation_backend is not None and batch_idx % sync_interval == 0:
+            generation_backend.sync_weights_from_model(model, self.tokenizer, batch_idx)
 
         train_state["model"] = model
         train_state["optimizer"] = optimizer
@@ -287,36 +338,37 @@ class PolicyGradientTrainer:
 
         num_words_in_completions: torch.Tensor = rollout_stats["num_words_in_completions"]
 
-        self.logger(
-            {
-                "train/mean_batch_returns": returns.mean().item(),
-                "train/max_batch_returns": returns.max().item(),
-                "train/min_batch_returns": returns.min().item(),
-                
-                "train/mean_batch_solved_rate": batch_mean_solved_rate,
+        log_payload = {
+            "train/mean_batch_returns": returns.mean().item(),
+            "train/max_batch_returns": returns.max().item(),
+            "train/min_batch_returns": returns.min().item(),
 
-                "train/mean_batch_format_returns": format_returns.mean().item(),
-                "train/max_batch_format_returns": format_returns.max().item(),
-                "train/min_batch_format_returns": format_returns.min().item(),
+            "train/mean_batch_solved_rate": batch_mean_solved_rate,
 
-                "train/mean_batch_outcome_returns": outcome_returns.mean().item(),
-                "train/max_batch_outcome_returns": outcome_returns.max().item(),
-                "train/min_batch_outcome_returns": outcome_returns.min().item(),
+            "train/mean_batch_format_returns": format_returns.mean().item(),
+            "train/max_batch_format_returns": format_returns.max().item(),
+            "train/min_batch_format_returns": format_returns.min().item(),
 
-                "train/mean_batch_length_penalty": length_penalty.mean().item(),
-                "train/max_batch_length_penalty": length_penalty.max().item(),
-                "train/min_batch_length_penalty": length_penalty.min().item(),
+            "train/mean_batch_outcome_returns": outcome_returns.mean().item(),
+            "train/max_batch_outcome_returns": outcome_returns.max().item(),
+            "train/min_batch_outcome_returns": outcome_returns.min().item(),
 
-                "train/mean_num_words_in_completions": num_words_in_completions.mean().item(),
-                "train/max_num_words_in_completions": num_words_in_completions.max().item(),
-                "train/min_num_words_in_completions": num_words_in_completions.min().item(),
-                
-                "train/lr": rollout_stats["rl_scheduler"].get_lr()[0],
-                "train/mean_action_entropy": rollout_stats["mean_action_entropy"].item(),
-                
-                "num_batches_visited": batch_idx,
-            }
-        )
+            "train/mean_batch_length_penalty": length_penalty.mean().item(),
+            "train/max_batch_length_penalty": length_penalty.max().item(),
+            "train/min_batch_length_penalty": length_penalty.min().item(),
+
+            "train/mean_num_words_in_completions": num_words_in_completions.mean().item(),
+            "train/max_num_words_in_completions": num_words_in_completions.max().item(),
+            "train/min_num_words_in_completions": num_words_in_completions.min().item(),
+
+            "train/lr": rollout_stats["rl_scheduler"].get_lr()[0],
+            "num_batches_visited": batch_idx,
+        }
+        mean_action_entropy = rollout_stats.get("mean_action_entropy")
+        if mean_action_entropy is not None:
+            log_payload["train/mean_action_entropy"] = mean_action_entropy.item()
+
+        self.logger(log_payload)
         ad_cispo_stats: ADCispoStats | None = rollout_stats.get("ad_cispo_stats")
         if ad_cispo_stats is not None:
             self.logger(
@@ -330,23 +382,32 @@ class PolicyGradientTrainer:
                 }
             )
 
-        if self.training_setup["base_config"].train_text_log_interval > 0:
-            if batch_idx % self.training_setup["base_config"].train_text_log_interval == 0:
-                file_name = Path(self.training_setup["train_log_dir"]) / f"log_{batch_idx}.txt"
-                with open(file_name, "a") as f:
-                    for i, completion in enumerate(rollout_stats["completions"]):
-                        question = rollout_stats["question"][i//self.generation_config.num_return_sequences]
-                        answer = rollout_stats["answer"][i//self.generation_config.num_return_sequences]
-                        reward = rollout_stats["returns"][i]
-                        info = info_list[i]     
-
-                        text_to_log = LOGGING_TEMPLATE.format(
-                            question=question,
-                            answer=answer,
-                            completion=completion,
-                            reward=reward,
-                            info=info,
-                        )
-                        f.write(text_to_log)
-                f.close()
+        text_log_interval = self.training_setup["base_config"].train_text_log_interval
+        if text_log_interval > 0 and batch_idx % text_log_interval == 0:
+            repeated_questions = [
+                rollout_stats["question"][i // self.generation_config.num_return_sequences]
+                for i in range(len(rollout_stats["completions"]))
+            ]
+            repeated_answers = [
+                rollout_stats["answer"][i // self.generation_config.num_return_sequences]
+                for i in range(len(rollout_stats["completions"]))
+            ]
+            sample_rows = build_completion_sample_rows(
+                phase="train",
+                batch_idx=batch_idx,
+                questions=repeated_questions,
+                answers=repeated_answers,
+                completions=rollout_stats["completions"],
+                rewards=rollout_stats["returns"].reshape(-1).tolist(),
+                infos=info_list,
+                max_samples=self.training_setup["base_config"].completion_log_sample_size,
+            )
+            file_name = Path(self.training_setup["train_log_dir"]) / f"log_{batch_idx}.txt"
+            with open(file_name, "a") as f:
+                f.write(format_completion_sample_rows(sample_rows))
+            log_completion_sample_table(
+                logger=self.logger,
+                key="train/completion_samples",
+                rows=sample_rows,
+            )
     

--- a/curious/train/training_setup.py
+++ b/curious/train/training_setup.py
@@ -1,6 +1,5 @@
-from typing import TypedDict, Optional, Tuple
+from typing import Any, TypedDict, Optional, Tuple
 import os
-import json
 from curious.data.gsm8k import GSM8KDataset
 from curious.utils.utils import load_model_tokenizer
 from curious.config import TrainingConfig, BaseConfig, RLConfig, SamplingConfig, RewardConfig
@@ -49,7 +48,7 @@ class TrainingSetup(TypedDict):
     dataset: GSM8KDataset
     rollout_data_loader: DataLoader
 
-    use_vllm: bool
+    generation_backend: Optional[Any]
 
     optimizer: optim.Optimizer
     lr_scheduler: optim.lr_scheduler.CosineAnnealingLR
@@ -67,6 +66,11 @@ class TrainingSetup(TypedDict):
     sampling_config: SamplingConfig
     reward_config: RewardConfig
 
+
+def needs_reference_policy(rl_config: RLConfig) -> bool:
+    return rl_config.kl_weight > 0 or rl_config.use_ad_cispo
+
+
 def set_up_training(config:TrainingConfig) -> Tuple[TrainingSetup, TrainState]: 
     """
     Set up the training.
@@ -82,6 +86,19 @@ def set_up_training(config:TrainingConfig) -> Tuple[TrainingSetup, TrainState]:
     assert config.base_config.mode == "train"
     assert config.rl_config.mini_batch_size % config.rl_config.group_size == 0
     assert config.base_config.train_batch_size * config.rl_config.group_size % config.rl_config.mini_batch_size == 0
+    if config.base_config.deepspeed_config is not None:
+        raise ValueError("DeepSpeed is disabled for this launch path; leave base_config.deepspeed_config unset.")
+    if config.sampling_config.generation_backend not in {"hf", "sglang"}:
+        raise ValueError("sampling_config.generation_backend must be one of: hf, sglang")
+    if config.sampling_config.generation_backend == "sglang":
+        if config.sampling_config.sglang_attention_backend != "fa3":
+            raise ValueError("SGLang baseline requires sglang_attention_backend='fa3' on H100")
+        if not (0 < config.sampling_config.sglang_mem_fraction_static < 1):
+            raise ValueError("sglang_mem_fraction_static must be between 0 and 1")
+        if config.sampling_config.sglang_weight_sync != "disk":
+            raise ValueError("Only sglang_weight_sync='disk' is currently supported")
+        if config.sampling_config.sglang_weight_sync_interval < 1:
+            raise ValueError("sglang_weight_sync_interval must be >= 1")
     if config.rl_config.use_rloo_scalar and config.rl_config.group_size <= 1:
         raise ValueError("RLOO advantages require group_size > 1")
     if config.rl_config.use_rloo_scalar and config.rl_config.normalize_centered_returns:
@@ -178,7 +195,7 @@ def set_up_training(config:TrainingConfig) -> Tuple[TrainingSetup, TrainState]:
     )
     training_setup["rollout_data_loader"] = rollout_data_loader
 
-    needs_reference_model = config.rl_config.kl_weight > 0 or config.rl_config.use_ad_cispo
+    needs_reference_model = needs_reference_policy(config.rl_config)
 
     if config.rl_config.kl_weight > 0:
         # kl controller
@@ -262,6 +279,7 @@ def set_up_training(config:TrainingConfig) -> Tuple[TrainingSetup, TrainState]:
         wandb_config=config.wandb_config,
         base_config=config.base_config,
         sampling_config=FixedSamplingConfig(
+            max_new_tokens=config.sampling_config.max_new_tokens,
             system_prompt=config.sampling_config.system_prompt,
             model_prompt_length=config.sampling_config.model_prompt_length,
         ),
@@ -285,28 +303,28 @@ def set_up_training(config:TrainingConfig) -> Tuple[TrainingSetup, TrainState]:
         eta_min=config.rl_config.lr * 1e-03,
     )
 
-    # deepspeed
-    if config.base_config.deepspeed_config is not None:
-        print(f"#### Setting up deepspeed from {config.base_config.deepspeed_config} ####")
-        with open(config.base_config.deepspeed_config, "r") as f:
-            deepspeed_config = json.load(f)
-        f.close()
-
-        deepspeed_config["train_micro_batch_size_per_gpu"] = config.rl_config.mini_batch_size
-        assert deepspeed_config["bf16"]["enabled"], "Only bfloat16 is supported for now"
-
-        import deepspeed
-        engine, optimizer, _, lr_scheduler = deepspeed.initialize(
-            model = model,
-            model_parameters = model.parameters(),
-            optimizer = optimizer,
-            lr_scheduler = lr_scheduler,
-            config = deepspeed_config,
-        )
-        training_setup["target_policy"] = engine 
-
     training_setup["optimizer"] = optimizer
-    training_setup["lr_scheduler"] = lr_scheduler   
+    training_setup["lr_scheduler"] = lr_scheduler
+
+    if config.sampling_config.generation_backend == "sglang":
+        from curious.sampling.sglang_backend import SGLangGenerationBackend
+
+        training_setup["generation_backend"] = SGLangGenerationBackend(
+            model_path=config.base_config.model_name,
+            tokenizer=tokenizer,
+            host=config.sampling_config.sglang_host,
+            port=config.sampling_config.sglang_port,
+            attention_backend=config.sampling_config.sglang_attention_backend,
+            mem_fraction_static=config.sampling_config.sglang_mem_fraction_static,
+            log_level=config.sampling_config.sglang_log_level,
+            startup_timeout=config.sampling_config.sglang_startup_timeout,
+            weight_sync_dir=config.sampling_config.sglang_weight_sync_dir,
+            max_running_requests=config.sampling_config.sglang_max_running_requests,
+            chunked_prefill_size=config.sampling_config.sglang_chunked_prefill_size,
+            request_batch_size=config.sampling_config.sglang_request_batch_size,
+        )
+    else:
+        training_setup["generation_backend"] = None
 
     return training_setup, TrainState(
         run_name=run_name,

--- a/curious/training.py
+++ b/curious/training.py
@@ -6,26 +6,22 @@ import tyro
 import wandb
 
 if __name__ == "__main__":
-    
     args = tyro.cli(TrainingConfig)
     training_setup, init_train_state = set_up_training(args)
-    
+
     wandb.init(
-        entity="moed",
+        entity=args.wandb_config.entity,
         project=args.wandb_config.project,
         name=args.wandb_config.name,
+        group=args.wandb_config.group,
         config=args,
     )
     wandb.define_metric("num_batches_visited")
-    wandb.define_metric("train/mean_batch_returns", step_metric="num_batches_visited")
-    wandb.define_metric("train/mean_batch_solved_rate", step_metric="num_batches_visited")
-    wandb.define_metric("train/max_input_length", step_metric="num_batches_visited")
-    wandb.define_metric("train/mean_num_words_in_completions", step_metric="num_batches_visited")
-    wandb.define_metric("train/mean_batch_format_returns", step_metric="num_batches_visited")
-    wandb.define_metric("train/mean_batch_outcome_returns", step_metric="num_batches_visited")
+    wandb.define_metric("train/*", step_metric="num_batches_visited")
+    wandb.define_metric("eval/*", step_metric="num_batches_visited")
+    wandb.define_metric("ad_cispo/*", step_metric="num_batches_visited")
 
     trainer = PolicyGradientTrainer(training_setup)
+    trainer.logger = wandb.log
     trainer.train(init_train_state)
-   
-        
-        
+    wandb.finish()

--- a/curious/utils/utils.py
+++ b/curious/utils/utils.py
@@ -6,7 +6,7 @@ from transformers import (
     AutoModelForCausalLM,
 )
 import datasets
-from typing import List, Dict, Optional, Union, Any, Tuple
+from typing import Callable, List, Dict, Optional, Union, Any, Tuple
 import torch
 
 from curious.prompt import * 
@@ -35,6 +35,99 @@ Info:
 
 """
 ).strip()
+
+COMPLETION_SAMPLE_COLUMNS = [
+    "phase",
+    "batch_idx",
+    "sample_idx",
+    "question",
+    "answer",
+    "completion",
+    "reward",
+    "info",
+]
+
+
+def _to_loggable_scalar(value: Any) -> Any:
+    if hasattr(value, "detach"):
+        value = value.detach().cpu()
+    if hasattr(value, "item"):
+        return value.item()
+    return value
+
+
+def build_completion_sample_rows(
+    *,
+    phase: str,
+    batch_idx: int,
+    questions: List[Any],
+    answers: List[Any],
+    completions: List[str],
+    rewards: List[Any],
+    infos: List[Any],
+    max_samples: int,
+    sample_offset: int = 0,
+) -> List[Dict[str, Any]]:
+    if max_samples <= 0:
+        return []
+
+    rows: List[Dict[str, Any]] = []
+    for local_idx, (question, answer, completion, reward, info) in enumerate(
+        zip(questions, answers, completions, rewards, infos)
+    ):
+        if len(rows) >= max_samples:
+            break
+        rows.append(
+            {
+                "phase": phase,
+                "batch_idx": batch_idx,
+                "sample_idx": sample_offset + local_idx,
+                "question": str(question),
+                "answer": str(answer),
+                "completion": completion,
+                "reward": _to_loggable_scalar(reward),
+                "info": str(info),
+            }
+        )
+    return rows
+
+
+def format_completion_sample_rows(rows: List[Dict[str, Any]]) -> str:
+    return "\n".join(
+        LOGGING_TEMPLATE.format(
+            question=row["question"],
+            answer=row["answer"],
+            completion=row["completion"],
+            reward=row["reward"],
+            info=row["info"],
+        )
+        for row in rows
+    )
+
+
+def log_completion_sample_table(
+    *,
+    logger: Callable[[Dict[str, Any]], None],
+    key: str,
+    rows: List[Dict[str, Any]],
+) -> None:
+    if not rows:
+        return
+
+    data = [[row[column] for column in COMPLETION_SAMPLE_COLUMNS] for row in rows]
+    try:
+        import wandb
+
+        value: Any = wandb.Table(columns=COMPLETION_SAMPLE_COLUMNS, data=data)
+    except Exception:
+        value = data
+
+    logger(
+        {
+            key: value,
+            "num_batches_visited": rows[0]["batch_idx"],
+        }
+    )
 
 
 def release_memory(vars:List[Any]):
@@ -185,19 +278,29 @@ def load_model_tokenizer(
         tuple: A tuple containing the model and its tokenizer.
     """
     tokenizer: PreTrainedTokenizer = AutoTokenizer.from_pretrained(model_name_or_path)
+    resolved_model_path = model_name_or_path if checkpoint_path is None else checkpoint_path
 
     if torch.cuda.is_available():
         from liger_kernel.transformers import AutoLigerKernelForCausalLM
-        model: PreTrainedModel = AutoLigerKernelForCausalLM.from_pretrained(
-            model_name_or_path if checkpoint_path is None else checkpoint_path,
-            trust_remote_code=trust_remote_code,
-            attn_implementation="flash_attention_2",
-            torch_dtype=dtype_,
-            device_map=device_map,
-        )
+        try:
+            model: PreTrainedModel = AutoLigerKernelForCausalLM.from_pretrained(
+                resolved_model_path,
+                trust_remote_code=trust_remote_code,
+                attn_implementation="flash_attention_2",
+                torch_dtype=dtype_,
+                device_map=device_map,
+            )
+        except KeyError as exc:
+            print(f"Liger does not support this model type ({exc}); falling back to AutoModelForCausalLM.")
+            model = AutoModelForCausalLM.from_pretrained(
+                resolved_model_path,
+                trust_remote_code=trust_remote_code,
+                torch_dtype=dtype_,
+                device_map=device_map,
+            )
     else:
         model: PreTrainedModel = AutoModelForCausalLM.from_pretrained(
-            model_name_or_path if checkpoint_path is None else checkpoint_path,
+            resolved_model_path,
             trust_remote_code=trust_remote_code,
             torch_dtype=dtype_,
         )

--- a/experiments/baseline_gsm8k_grpo/README.md
+++ b/experiments/baseline_gsm8k_grpo/README.md
@@ -1,0 +1,72 @@
+# Baseline GSM8K GRPO Modal Run
+
+This is the prepared baseline GRPO run configuration for GSM8K on Modal H100.
+It is intentionally not launched by default.
+
+## Launch
+
+```bash
+scripts/launch_baseline_gsm8k_grpo_modal.sh
+```
+
+The launch script defaults to a background Modal run so the terminal returns
+after Modal accepts the call. It requires one of:
+
+- `WANDB_API_KEY` exported locally
+- a local `.env` containing `WANDB_API_KEY`
+- `MODAL_SECRET=<secret-name>` pointing to a Modal Secret that contains W&B credentials
+
+Useful overrides:
+
+```bash
+RUN_NAME=baseline-gsm8k-grpo-qwen3-0p6b-sglang-fa3-h100-seed42-v2 \
+WANDB_ENTITY=autocurriculum \
+WANDB_PROJECT=curious \
+MODAL_GPU=H100 \
+BACKGROUND=1 \
+scripts/launch_baseline_gsm8k_grpo_modal.sh
+```
+
+## Monitor
+
+```bash
+scripts/monitor_baseline_gsm8k_grpo.sh
+```
+
+The monitor polls:
+
+- W&B run state and summary metrics under `autocurriculum/curious`
+- Modal app state for `curious-training`
+
+Useful overrides:
+
+```bash
+POLL_SECONDS=30 scripts/monitor_baseline_gsm8k_grpo.sh --show-modal-logs
+```
+
+## Baseline Config
+
+- Model: `Qwen/Qwen3-0.6B`
+- Dataset: `openai/gsm8k`
+- Modal GPU: `H100`
+- Generation backend: `SGLang`
+- SGLang attention backend: `fa3`
+- SGLang static memory fraction: `0.40`
+- DeepSpeed: disabled
+- Train batch size: `4`
+- GRPO group size: `16`
+- Minibatch size: `64`
+- PPO epochs per rollout: `1`
+- Learning rate: `5e-6`
+- Weight decay: `0.01`
+- Clip epsilon: `0.2`
+- KL weight: `0.0`
+- AD-CISPO: disabled
+- RLOO: disabled
+- Max prompt length: `1024`
+- Max new tokens: `384`
+- Sampling: temperature `0.7`, top-p `0.9`, top-k `50`
+
+This starts from Qwen3 0.6B so the H100 run can use SGLang's
+FlashAttention-3 path for fast rollout inference. The small train batch and
+shorter decode cap keep memory pressure conservative while KL/AD-CISPO are off.

--- a/experiments/baseline_gsm8k_grpo/baseline_research_report.html
+++ b/experiments/baseline_gsm8k_grpo/baseline_research_report.html
@@ -1,0 +1,206 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Baseline GSM8K GRPO Research Report</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --ink: #1f2933;
+      --muted: #5f6b7a;
+      --line: #d7dee8;
+      --panel: #f7f9fc;
+      --accent: #0f766e;
+      --warn: #9a3412;
+    }
+    body {
+      margin: 0;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      color: var(--ink);
+      background: #ffffff;
+      line-height: 1.55;
+    }
+    main {
+      max-width: 980px;
+      margin: 0 auto;
+      padding: 42px 28px 64px;
+    }
+    h1, h2, h3 {
+      line-height: 1.2;
+      margin: 0 0 12px;
+    }
+    h1 {
+      font-size: 34px;
+      letter-spacing: 0;
+    }
+    h2 {
+      margin-top: 34px;
+      font-size: 22px;
+      border-bottom: 1px solid var(--line);
+      padding-bottom: 8px;
+    }
+    h3 {
+      margin-top: 22px;
+      font-size: 17px;
+    }
+    p {
+      margin: 8px 0 14px;
+    }
+    .meta {
+      color: var(--muted);
+      margin-top: 8px;
+    }
+    .summary {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+      gap: 12px;
+      margin: 24px 0;
+    }
+    .metric {
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 14px 16px;
+    }
+    .metric strong {
+      display: block;
+      font-size: 22px;
+      margin-top: 4px;
+    }
+    .metric span {
+      color: var(--muted);
+      font-size: 13px;
+    }
+    table {
+      border-collapse: collapse;
+      width: 100%;
+      margin: 14px 0 20px;
+      font-size: 14px;
+    }
+    th, td {
+      border: 1px solid var(--line);
+      padding: 9px 10px;
+      text-align: left;
+      vertical-align: top;
+    }
+    th {
+      background: var(--panel);
+    }
+    code {
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 0.95em;
+    }
+    .callout {
+      border-left: 4px solid var(--accent);
+      background: #eefaf8;
+      padding: 12px 16px;
+      margin: 18px 0;
+    }
+    .warning {
+      border-left-color: var(--warn);
+      background: #fff7ed;
+    }
+    ul {
+      padding-left: 22px;
+    }
+    a {
+      color: #075985;
+    }
+  </style>
+</head>
+<body>
+<main>
+  <h1>Baseline GSM8K GRPO Research Report</h1>
+  <p class="meta">Generated 2026-06-02 after Modal H100 staging run <code>baseline-gsm8k-grpo-qwen3-0p6b-sglang-fa3-h100-seed42-v6</code>.</p>
+
+  <section class="summary">
+    <div class="metric"><span>Final observed W&amp;B counter</span><strong>55</strong></div>
+    <div class="metric"><span>Current batch solved rate</span><strong>0.484375</strong></div>
+    <div class="metric"><span>Current batch return</span><strong>0.078125</strong></div>
+    <div class="metric"><span>Grad norm</span><strong>2.03125</strong></div>
+  </section>
+
+  <h2>Executive Summary</h2>
+  <p>The baseline GRPO run against <code>Qwen/Qwen3-0.6B</code> on GSM8K was launched on Modal H100 in the <code>rundong-liu-eric</code> workspace and monitored through W&amp;B and Modal logs. The reliable run was <code>v6</code>, after removing Torch Dynamo/Inductor compilation from the log-probability path. It reached W&amp;B counter 55 and Modal log batch 55 before the H100 job was stopped to avoid an unbounded 24h run.</p>
+  <p>The final observed batch had a nonzero learning signal: solved rate <code>0.484375</code>, return <code>0.078125</code>, actor loss <code>0.00040435791015625</code>, and grad norm <code>2.03125</code>. KL is expected to be zero because the baseline launch sets <code>kl_weight=0.0</code>.</p>
+
+  <div class="callout warning">
+    <strong>Scope note:</strong> this is a staged baseline report, not a completed full-epoch GSM8K report. The active trainer path does not checkpoint or evaluate, and observed throughput projects a full epoch beyond the configured 24h Modal timeout.
+  </div>
+
+  <h2>Access and Environment</h2>
+  <table>
+    <tr><th>System</th><th>Observed access</th></tr>
+    <tr><td>W&amp;B</td><td>Project access confirmed for <code>autocurriculum/curious</code> as user <code>rundong-liu-eric</code>.</td></tr>
+    <tr><td>Modal</td><td>Profile and workspace confirmed as <code>rundong-liu-eric</code>, environment <code>main</code>.</td></tr>
+    <tr><td>Modal CLI</td><td><code>/Users/ericliu/.local/bin/modal</code>, version <code>1.4.3</code>.</td></tr>
+    <tr><td>GPU</td><td><code>NVIDIA H100 80GB HBM3</code>, confirmed by W&amp;B metadata and live Modal <code>nvidia-smi</code>.</td></tr>
+  </table>
+
+  <h2>Run Configuration</h2>
+  <table>
+    <tr><th>Field</th><th>Value</th></tr>
+    <tr><td>Model</td><td><code>Qwen/Qwen3-0.6B</code></td></tr>
+    <tr><td>Dataset</td><td><code>openai/gsm8k</code>, train split</td></tr>
+    <tr><td>GPU</td><td>Modal <code>H100</code></td></tr>
+    <tr><td>Generation backend</td><td><code>sglang</code></td></tr>
+    <tr><td>SGLang attention backend</td><td><code>fa3</code></td></tr>
+    <tr><td>Train batch size</td><td><code>4</code></td></tr>
+    <tr><td>GRPO group size</td><td><code>16</code></td></tr>
+    <tr><td>Mini-batch size</td><td><code>16</code></td></tr>
+    <tr><td>Max new tokens</td><td><code>384</code></td></tr>
+    <tr><td>Learning rate</td><td><code>5e-6</code></td></tr>
+    <tr><td>KL weight</td><td><code>0.0</code></td></tr>
+    <tr><td>AD-CISPO / RLOO</td><td>Disabled</td></tr>
+  </table>
+
+  <h2>Launch Timeline</h2>
+  <table>
+    <tr><th>Run</th><th>Outcome</th></tr>
+    <tr><td><code>v3</code></td><td>Reached H100 and initialized W&amp;B, but produced no metrics after local interruption.</td></tr>
+    <tr><td><code>v4</code></td><td>Background launch created app <code>ap-WSQbKvxABlz3oX78u7VfVz</code> and call <code>fc-01KT51ZN66S7YFZ46CHQYNGB5M</code>, then stopped before a W&amp;B run appeared.</td></tr>
+    <tr><td><code>v5</code></td><td>Attached launch created app <code>ap-ecf0fEY1S30jfdG0WaNyGF</code> and W&amp;B run <code>r4dw7413</code>, but stalled before first update while Torch Dynamo/Inductor compiled the log-probability path.</td></tr>
+    <tr><td><code>v6</code></td><td>Successful staged baseline after the eager log-prob fix. App <code>ap-hoZIYGe2xQpNTWwwe0L6ET</code>, call <code>fc-01KT530MNE5K1YQM6HGWBVP9EN</code>, W&amp;B run <code>npw100co</code>.</td></tr>
+  </table>
+
+  <h2>Final Observed Metrics</h2>
+  <table>
+    <tr><th>Metric</th><th>Value at W&amp;B counter 55</th></tr>
+    <tr><td><code>train/mean_batch_returns</code></td><td><code>0.078125</code></td></tr>
+    <tr><td><code>train/mean_batch_solved_rate</code></td><td><code>0.484375</code></td></tr>
+    <tr><td><code>train/mean_batch_outcome_returns</code></td><td><code>0.078125</code></td></tr>
+    <tr><td><code>train/mean_num_words_in_completions</code></td><td><code>230</code></td></tr>
+    <tr><td><code>train/mean_action_entropy</code></td><td><code>0.49609375</code></td></tr>
+    <tr><td><code>train/loss</code></td><td><code>0.00040435791015625</code></td></tr>
+    <tr><td><code>train/actor_loss</code></td><td><code>0.00040435791015625</code></td></tr>
+    <tr><td><code>train/mean_kl</code></td><td><code>0</code></td></tr>
+    <tr><td><code>train/grad_norm</code></td><td><code>2.03125</code></td></tr>
+    <tr><td><code>train/lr</code></td><td><code>5e-6</code></td></tr>
+  </table>
+
+  <h2>Operational Findings</h2>
+  <ul>
+    <li>The project <code>uv</code> environment has working W&amp;B access. The Homebrew <code>wandb</code> CLI is broken locally because it imports an older W&amp;B package against NumPy 2.x.</li>
+    <li>The launcher should be run attached for this workflow. The current <code>--background</code> path returned before the remote training call became observable.</li>
+    <li>Removing <code>@torch.compile(dynamic=True)</code> from <code>compute_group_advantages</code>, <code>_sequence_log_probs_from_logits</code>, and <code>sequences_log_probs</code> fixed the first-batch stall.</li>
+    <li>The active <code>PolicyGradientTrainer</code> path does not use the configured checkpoint or evaluation intervals, so long runs do not automatically produce checkpoints or eval tables.</li>
+    <li>The run repeatedly reloads a safetensors checkpoint after updates during SGLang weight sync. This is functional, but it contributes visible overhead.</li>
+  </ul>
+
+  <h2>Throughput and Feasibility</h2>
+  <p>The run started W&amp;B around 2026-06-02T21:15:33Z and was stopped after W&amp;B counter 55 around 2026-06-02T22:08:26Z. The rough sustained throughput is about one completed batch per minute after startup. GSM8K train has 7,473 examples, and with train batch size 4 the full train epoch is about 1,869 batches. At this observed rate, a full epoch projects to roughly 30 hours, longer than the configured 24h Modal timeout.</p>
+
+  <h2>Conclusion</h2>
+  <p>The baseline GRPO stack is launchable on Modal H100 and produces W&amp;B metrics after the eager log-prob fix. The final staged snapshot shows nonzero reward and gradient signal, so the run is no longer blocked at infrastructure or first-batch compilation. The next engineering step is to add an explicit max-batch/checkpoint/eval contract to the trainer or switch to the older RL train path that already handles checkpoint and evaluation intervals, then rerun a bounded baseline that can finish cleanly and produce comparable final artifacts.</p>
+
+  <h2>Artifacts</h2>
+  <ul>
+    <li>Staging report: <code>experiments/baseline_gsm8k_grpo/staging_report.md</code></li>
+    <li>Metric snapshot: <code>experiments/baseline_gsm8k_grpo/wandb_metrics_npw100co.json</code></li>
+    <li>W&amp;B run: <a href="https://wandb.ai/autocurriculum/curious/runs/npw100co">https://wandb.ai/autocurriculum/curious/runs/npw100co</a></li>
+    <li>Modal app: <a href="https://modal.com/apps/rundong-liu-eric/main/ap-hoZIYGe2xQpNTWwwe0L6ET">https://modal.com/apps/rundong-liu-eric/main/ap-hoZIYGe2xQpNTWwwe0L6ET</a></li>
+  </ul>
+</main>
+</body>
+</html>

--- a/experiments/baseline_gsm8k_grpo/staging_report.md
+++ b/experiments/baseline_gsm8k_grpo/staging_report.md
@@ -1,0 +1,47 @@
+# Baseline GSM8K GRPO Staging Report
+
+Generated: 2026-06-02T21:31:03Z
+
+## Access Checks
+
+- W&B access works through the project `uv` environment.
+- W&B user: `rundong-liu-eric` / Rundong Liu.
+- W&B project access: `autocurriculum/curious`.
+- Modal profile: `rundong-liu-eric`.
+- Modal workspace: `rundong-liu-eric`, environment `main`.
+- Modal CLI used for launch: `/Users/ericliu/.local/bin/modal`, version `1.4.3`.
+- Modal H100 access is confirmed by W&B run metadata and live `nvidia-smi` output: `NVIDIA H100 80GB HBM3`.
+
+## Launches
+
+- `v3`: reached a Modal H100 container and initialized W&B, but produced no metrics. The local launcher had been interrupted and no Modal app/container was listed by the time it was inspected.
+- `v4`: launched with `--background`, created app `ap-WSQbKvxABlz3oX78u7VfVz`, printed function call `fc-01KT51ZN66S7YFZ46CHQYNGB5M`, then stopped before any W&B run appeared. The background path is not reliable for this launcher.
+- `v5`: attached run, app `ap-ecf0fEY1S30jfdG0WaNyGF`, function call `fc-01KT5210W4MVNQZ921SCJQSEAG`, W&B run `r4dw7413`. It reached epoch 0 but stalled before completing the first update. Evidence: no metrics after about 14 minutes, H100 memory resident at about 24 GB, GPU utilization 0%, and logs showed Torch Dynamo/Inductor compile warnings in the `sequences_log_probs` path.
+- `v6`: attached run after removing `torch.compile` wrappers from the log-prob/advantage helpers. App `ap-hoZIYGe2xQpNTWwwe0L6ET`, function call `fc-01KT530MNE5K1YQM6HGWBVP9EN`, W&B run `npw100co`.
+
+## Current v6 Status
+
+- State: running.
+- W&B URL: https://wandb.ai/autocurriculum/curious/runs/npw100co
+- Modal URL: https://modal.com/apps/rundong-liu-eric/main/ap-hoZIYGe2xQpNTWwwe0L6ET
+- Latest observed batch: `num_batches_visited = 55` as of the final W&B snapshot after stopping the Modal app.
+- Latest metrics:
+  - `train/mean_batch_returns = 0.078125`
+  - `train/mean_batch_solved_rate = 0.484375`
+  - `train/mean_batch_outcome_returns = 0.078125`
+  - `train/mean_num_words_in_completions = 230`
+  - `train/mean_action_entropy = 0.49609375`
+  - `train/loss = 0.00040435791015625`
+  - `train/actor_loss = 0.00040435791015625`
+  - `train/mean_kl = 0`
+  - `train/grad_norm = 2.03125`
+  - `train/lr = 5e-6`
+- Modal memory at rollout logs remained stable around 4.5 GB allocated and 7.0 GB reserved through batch 55, with max reserved 26.8 GB.
+- Modal app `ap-hoZIYGe2xQpNTWwwe0L6ET` was stopped manually after collecting the staged baseline snapshot; no Modal containers are currently active.
+
+## Notes
+
+- The Homebrew `wandb` CLI is broken locally because it imports an older W&B package against NumPy 2.x. The project `uv` environment works and is what the monitor uses.
+- `scripts/monitor_modal_wandb.py` can poll W&B and Modal, but its default run name is still `v2`; override `RUN_NAME=baseline-gsm8k-grpo-qwen3-0p6b-sglang-fa3-h100-seed42-v6`.
+- The full `PolicyGradientTrainer` path does not currently checkpoint or evaluate, despite launch flags setting checkpoint/eval intervals.
+- The observed throughput is roughly three completed batches per five minutes in the latest sample, so a full one-epoch GSM8K run may exceed the 24h Modal timeout unless throughput improves.

--- a/experiments/baseline_gsm8k_grpo/wandb_metrics_npw100co.json
+++ b/experiments/baseline_gsm8k_grpo/wandb_metrics_npw100co.json
@@ -1,0 +1,16 @@
+{
+  "summary": {
+    "num_batches_visited": 55,
+    "train/mean_batch_returns": 0.078125,
+    "train/mean_batch_solved_rate": 0.484375,
+    "train/mean_batch_outcome_returns": 0.078125,
+    "train/mean_num_words_in_completions": 230,
+    "train/mean_action_entropy": 0.49609375,
+    "train/loss": 0.00040435791015625,
+    "train/actor_loss": 0.00040435791015625,
+    "train/mean_kl": 0,
+    "train/grad_norm": 2.03125,
+    "train/lr": 5e-06
+  },
+  "rows": []
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,24 +11,22 @@ requires-python = ">=3.11,<3.13"
 dependencies = [
     "accelerate==1.6.0",
     "datasets==3.5.0",
-    "deepspeed==0.16.7; sys_platform == 'linux' and platform_machine == 'x86_64'",
     "diff-parser==1.1",
     "liger-kernel==0.5.8; sys_platform == 'linux' and platform_machine == 'x86_64'",
     "math-verify==0.7.0",
     "memory-profiler==0.61.0",
     "modal==1.4.3",
-    "mpi4py==4.0.3; sys_platform == 'linux' and platform_machine == 'x86_64'",
     "python-dotenv==1.1.0",
     "setuptools==76.1.0",
+    "sglang[srt]==0.4.6.post5; sys_platform == 'linux' and platform_machine == 'x86_64'",
     "toml==0.10.2",
     "torch==2.6.0",
-    "transformers==4.51.3",
+    "transformers==4.51.1",
     "tree-sitter==0.24.0",
     "trl==0.16.1",
     "tyro==0.9.18",
     "unidiff==0.7.5",
-    "vllm==0.8.4; sys_platform == 'linux' and platform_machine == 'x86_64'",
-    "wandb==0.19.9",
+    "wandb==0.27.0",
 ]
 
 [dependency-groups]

--- a/scripts/launch_baseline_gsm8k_grpo_modal.sh
+++ b/scripts/launch_baseline_gsm8k_grpo_modal.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${ROOT_DIR}"
+
+RUN_NAME="${RUN_NAME:-baseline-gsm8k-grpo-qwen3-0p6b-sglang-fa3-h100-seed42-v3}"
+WANDB_ENTITY="${WANDB_ENTITY:-autocurriculum}"
+WANDB_PROJECT="${WANDB_PROJECT:-curious}"
+WANDB_GROUP="${WANDB_GROUP:-baseline-grpo-gsm8k}"
+MODAL_GPU="${MODAL_GPU:-H100}"
+MODAL_TIMEOUT="${MODAL_TIMEOUT:-86400}"
+BACKGROUND="${BACKGROUND:-0}"
+MODAL_SECRET="${MODAL_SECRET:-}"
+DRY_RUN="${DRY_RUN:-0}"
+MODEL_NAME="${MODEL_NAME:-Qwen/Qwen3-0.6B}"
+TRAIN_BATCH_SIZE="${TRAIN_BATCH_SIZE:-32}"
+GROUP_SIZE="${GROUP_SIZE:-8}"
+MAX_NEW_TOKENS="${MAX_NEW_TOKENS:-256}"
+MINI_BATCH_SIZE="${MINI_BATCH_SIZE:-32}"
+LOGITS_MINIBATCH_SIZE="${LOGITS_MINIBATCH_SIZE:-${MINI_BATCH_SIZE}}"
+TRAIN_ENTROPY_LOG_INTERVAL="${TRAIN_ENTROPY_LOG_INTERVAL:-10}"
+EVAL_INTERVAL="${EVAL_INTERVAL:-10}"
+TRAIN_TEXT_LOG_INTERVAL="${TRAIN_TEXT_LOG_INTERVAL:-10}"
+EVAL_TEXT_LOG_INTERVAL="${EVAL_TEXT_LOG_INTERVAL:-10}"
+COMPLETION_LOG_SAMPLE_SIZE="${COMPLETION_LOG_SAMPLE_SIZE:-8}"
+KL_WEIGHT="${KL_WEIGHT:-0.001}"
+REF_MODEL_UPDATE_FREQ="${REF_MODEL_UPDATE_FREQ:-0}"
+SGLANG_MEM_FRACTION_STATIC="${SGLANG_MEM_FRACTION_STATIC:-0.20}"
+SGLANG_ATTENTION_BACKEND="${SGLANG_ATTENTION_BACKEND:-fa3}"
+SGLANG_REQUEST_BATCH_SIZE="${SGLANG_REQUEST_BATCH_SIZE:-16}"
+SGLANG_PORT="${SGLANG_PORT:-30000}"
+SGLANG_WEIGHT_SYNC_DIR="${SGLANG_WEIGHT_SYNC_DIR:-/tmp/curious-sglang-weight-sync}"
+SGLANG_WEIGHT_SYNC_INTERVAL="${SGLANG_WEIGHT_SYNC_INTERVAL:-1}"
+
+while (($#)); do
+  case "$1" in
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    --background)
+      BACKGROUND=1
+      shift
+      ;;
+    --foreground|--no-background)
+      BACKGROUND=0
+      shift
+      ;;
+    *)
+      echo "Unknown launch option: $1" >&2
+      echo "Supported options: --dry-run, --background, --foreground, --no-background" >&2
+      exit 2
+      ;;
+  esac
+done
+
+ROLLOUT_BATCH_SIZE=$((TRAIN_BATCH_SIZE * GROUP_SIZE))
+if (( MINI_BATCH_SIZE % GROUP_SIZE != 0 )); then
+  echo "MINI_BATCH_SIZE must be divisible by GROUP_SIZE: ${MINI_BATCH_SIZE} % ${GROUP_SIZE} != 0" >&2
+  exit 2
+fi
+if (( ROLLOUT_BATCH_SIZE % MINI_BATCH_SIZE != 0 )); then
+  echo "TRAIN_BATCH_SIZE * GROUP_SIZE must be divisible by MINI_BATCH_SIZE: ${ROLLOUT_BATCH_SIZE} % ${MINI_BATCH_SIZE} != 0" >&2
+  exit 2
+fi
+
+if [[ "${DRY_RUN}" != "1" && -z "${WANDB_API_KEY:-}" && -z "${MODAL_SECRET}" && ! -f ".env" ]]; then
+  echo "WANDB_API_KEY is not set, MODAL_SECRET is empty, and .env was not found." >&2
+  echo "Export WANDB_API_KEY, create .env, or set MODAL_SECRET to a Modal Secret name before launching." >&2
+  exit 2
+fi
+
+modal_args=(--gpu "${MODAL_GPU}" --timeout "${MODAL_TIMEOUT}")
+if [[ "${BACKGROUND}" == "1" ]]; then
+  modal_args+=(--background)
+fi
+if [[ -n "${MODAL_SECRET}" ]]; then
+  modal_args+=(--secret "${MODAL_SECRET}")
+fi
+
+echo "Preparing Modal baseline GRPO launch:"
+echo "  run: ${RUN_NAME}"
+echo "  W&B: ${WANDB_ENTITY}/${WANDB_PROJECT}"
+echo "  gpu: ${MODAL_GPU}"
+echo "  background: ${BACKGROUND}"
+echo "  dry_run: ${DRY_RUN}"
+echo "  model: ${MODEL_NAME}"
+echo "  generation_backend: sglang"
+echo "  sglang_attention_backend: ${SGLANG_ATTENTION_BACKEND}"
+echo "  sglang_mem_fraction_static: ${SGLANG_MEM_FRACTION_STATIC}"
+echo "  sglang_request_batch_size: ${SGLANG_REQUEST_BATCH_SIZE}"
+echo "  sglang_weight_sync_interval: ${SGLANG_WEIGHT_SYNC_INTERVAL}"
+echo "  train_batch_size: ${TRAIN_BATCH_SIZE}"
+echo "  group_size: ${GROUP_SIZE}"
+echo "  rollout_batch_size: ${ROLLOUT_BATCH_SIZE}"
+echo "  mini_batch_size: ${MINI_BATCH_SIZE}"
+echo "  logits_minibatch_size: ${LOGITS_MINIBATCH_SIZE}"
+echo "  train_entropy_log_interval: ${TRAIN_ENTROPY_LOG_INTERVAL}"
+echo "  eval_interval: ${EVAL_INTERVAL}"
+echo "  train_text_log_interval: ${TRAIN_TEXT_LOG_INTERVAL}"
+echo "  eval_text_log_interval: ${EVAL_TEXT_LOG_INTERVAL}"
+echo "  completion_log_sample_size: ${COMPLETION_LOG_SAMPLE_SIZE}"
+echo "  kl_weight: ${KL_WEIGHT}"
+echo "  ref_model_update_freq: ${REF_MODEL_UPDATE_FREQ} (frozen reference)"
+
+command=(scripts/modal_train.sh "${modal_args[@]}" -- \
+  --wandb-config.entity "${WANDB_ENTITY}" \
+  --wandb-config.project "${WANDB_PROJECT}" \
+  --wandb-config.group "${WANDB_GROUP}" \
+  --wandb-config.name "${RUN_NAME}" \
+  --base-config.model-name "${MODEL_NAME}" \
+  --base-config.device-index 0 \
+  --base-config.dataset-name "openai/gsm8k" \
+  --base-config.train-batch-size "${TRAIN_BATCH_SIZE}" \
+  --base-config.eval-batch-size 512 \
+  --base-config.num-epochs 1 \
+  --base-config.num-workers 16 \
+  --base-config.seed 42 \
+  --base-config.checkpoint-interval 50 \
+  --base-config.eval-interval "${EVAL_INTERVAL}" \
+  --base-config.train-text-log-interval "${TRAIN_TEXT_LOG_INTERVAL}" \
+  --base-config.train-entropy-log-interval "${TRAIN_ENTROPY_LOG_INTERVAL}" \
+  --base-config.eval-text-log-interval "${EVAL_TEXT_LOG_INTERVAL}" \
+  --base-config.completion-log-sample-size "${COMPLETION_LOG_SAMPLE_SIZE}" \
+  --sampling-config.model-prompt-length 1024 \
+  --sampling-config.max-new-tokens "${MAX_NEW_TOKENS}" \
+  --sampling-config.temperature 0.7 \
+  --sampling-config.top-p 0.9 \
+  --sampling-config.top-k 50 \
+  --sampling-config.do-sample \
+  --sampling-config.use-cache \
+  --sampling-config.repetition-penalty 1.0 \
+  --sampling-config.system-prompt "qwen_system_prompt" \
+  --sampling-config.generation-backend sglang \
+  --sampling-config.sglang-attention-backend "${SGLANG_ATTENTION_BACKEND}" \
+  --sampling-config.sglang-mem-fraction-static "${SGLANG_MEM_FRACTION_STATIC}" \
+  --sampling-config.sglang-request-batch-size "${SGLANG_REQUEST_BATCH_SIZE}" \
+  --sampling-config.sglang-port "${SGLANG_PORT}" \
+  --sampling-config.sglang-weight-sync-dir "${SGLANG_WEIGHT_SYNC_DIR}" \
+  --sampling-config.sglang-weight-sync-interval "${SGLANG_WEIGHT_SYNC_INTERVAL}" \
+  --reward-config.no-use-format-reward \
+  --reward-config.no-use-overlong-penalty \
+  --rl-config.group-size "${GROUP_SIZE}" \
+  --rl-config.lr 3e-6 \
+  --rl-config.weight-decay 0.01 \
+  --rl-config.kl-weight "${KL_WEIGHT}" \
+  --rl-config.ref-model-update-freq "${REF_MODEL_UPDATE_FREQ}" \
+  --rl-config.clip-eps 0.2 \
+  --rl-config.no-use-clip-high \
+  --rl-config.no-use-token-level-loss \
+  --rl-config.no-use-fixed-response-length \
+  --rl-config.use-surrogate-loss \
+  --rl-config.no-use-ad-cispo \
+  --rl-config.mini-batch-size "${MINI_BATCH_SIZE}" \
+  --rl-config.epochs-per-step 1 \
+  --rl-config.max-grad-norm 0.5 \
+  --rl-config.normalize-centered-returns \
+  --rl-config.no-use-rloo-scalar \
+  --rl-config.logits-minibatch-size "${LOGITS_MINIBATCH_SIZE}")
+
+if [[ "${DRY_RUN}" == "1" ]]; then
+  printf 'Command:'
+  printf ' %q' "${command[@]}"
+  printf '\n'
+  exit 0
+fi
+
+exec "${command[@]}"

--- a/scripts/monitor_baseline_gsm8k_grpo.sh
+++ b/scripts/monitor_baseline_gsm8k_grpo.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${ROOT_DIR}"
+
+export WANDB_ENTITY="${WANDB_ENTITY:-autocurriculum}"
+export WANDB_PROJECT="${WANDB_PROJECT:-curious}"
+export RUN_NAME="${RUN_NAME:-baseline-gsm8k-grpo-qwen3-0p6b-sglang-fa3-h100-seed42-v3}"
+export MODAL_APP="${MODAL_APP:-curious-training}"
+export MODEL_NAME="${MODEL_NAME:-Qwen/Qwen3-0.6B}"
+export GENERATION_BACKEND="${GENERATION_BACKEND:-sglang}"
+export SGLANG_ATTENTION_BACKEND="${SGLANG_ATTENTION_BACKEND:-fa3}"
+
+exec uv run python scripts/monitor_modal_wandb.py "$@"

--- a/scripts/monitor_modal_wandb.py
+++ b/scripts/monitor_modal_wandb.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env -S uv run python
+import argparse
+import json
+import os
+import subprocess
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import wandb
+from dotenv import load_dotenv
+
+
+DEFAULT_METRICS = (
+    "num_batches_visited",
+    "train/mean_batch_returns",
+    "train/mean_batch_solved_rate",
+    "train/mean_batch_outcome_returns",
+    "train/mean_num_words_in_completions",
+    "train/mean_action_entropy",
+    "train/loss",
+    "train/actor_loss",
+    "train/mean_kl",
+    "train/kl_loss",
+    "train/kl_weight",
+    "train/kl_weight_used",
+    "train/kl_weight_next",
+    "train/grad_norm",
+    "train/lr",
+)
+
+
+def default_modal_bin() -> str:
+    uv_tool_modal = Path.home() / ".local" / "bin" / "modal"
+    if uv_tool_modal.exists():
+        return str(uv_tool_modal)
+    return "modal"
+
+
+def normalized_lookup(item: dict[str, Any], *candidate_keys: str) -> Any:
+    normalized = {
+        key.lower().replace(" ", "_").replace("-", "_"): value
+        for key, value in item.items()
+    }
+    for key in candidate_keys:
+        value = normalized.get(key.lower().replace(" ", "_").replace("-", "_"))
+        if value is not None:
+            return value
+    return None
+
+
+def find_wandb_run(entity: str, project: str, run_name: str) -> Any | None:
+    load_dotenv(Path.cwd() / ".env")
+    api = wandb.Api()
+    path = f"{entity}/{project}"
+
+    for filters in ({"display_name": run_name}, {"name": run_name}):
+        runs = list(api.runs(path, filters=filters, per_page=10))
+        if runs:
+            return runs[0]
+
+    recent_runs = list(api.runs(path, order="-created_at", per_page=50))
+    for run in recent_runs:
+        if run.name == run_name or run.id == run_name:
+            return run
+    return None
+
+
+def latest_wandb_metrics(run: Any, metric_keys: tuple[str, ...]) -> dict[str, Any]:
+    summary = dict(run.summary)
+    return {
+        key: summary.get(key)
+        for key in metric_keys
+        if summary.get(key) is not None
+    }
+
+
+def modal_app_list(modal_bin: str) -> list[dict[str, Any]]:
+    completed = subprocess.run(
+        [modal_bin, "app", "list", "--json"],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise RuntimeError(completed.stderr.strip() or completed.stdout.strip())
+    if not completed.stdout.strip():
+        return []
+    return json.loads(completed.stdout)
+
+
+def matching_modal_apps(apps: list[dict[str, Any]], app_name: str) -> list[dict[str, Any]]:
+    matches: list[dict[str, Any]] = []
+    for app in apps:
+        app_id = normalized_lookup(app, "app_id", "id")
+        description = normalized_lookup(app, "description", "name")
+        if app_name in {app_id, description}:
+            matches.append(app)
+    return matches
+
+
+def print_modal_state(modal_bin: str, app_name: str, show_logs: bool, log_tail: int) -> None:
+    apps = modal_app_list(modal_bin)
+    matches = matching_modal_apps(apps, app_name)
+    if not matches:
+        print(f"Modal: no app named or identified as {app_name!r} is currently listed.")
+        return
+
+    for app in matches:
+        app_id = normalized_lookup(app, "app_id", "id")
+        description = normalized_lookup(app, "description", "name")
+        state = normalized_lookup(app, "state")
+        tasks = normalized_lookup(app, "tasks")
+        created_at = normalized_lookup(app, "created_at")
+        print(f"Modal: app_id={app_id} description={description} state={state} tasks={tasks} created_at={created_at}")
+
+        if show_logs and app_id:
+            logs = subprocess.run(
+                [modal_bin, "app", "logs", str(app_id), "--tail", str(log_tail), "--timestamps"],
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+            if logs.returncode == 0 and logs.stdout.strip():
+                print("Modal logs:")
+                print(logs.stdout.rstrip())
+            elif logs.stderr.strip():
+                print(f"Modal logs unavailable: {logs.stderr.strip()}")
+
+
+def print_wandb_state(entity: str, project: str, run_name: str, metric_keys: tuple[str, ...]) -> None:
+    try:
+        run = find_wandb_run(entity=entity, project=project, run_name=run_name)
+    except Exception as exc:
+        print(f"W&B: project or run is not available yet: {exc}")
+        return
+    if run is None:
+        print(f"W&B: run {entity}/{project}/{run_name!r} not found yet.")
+        return
+
+    run.load(force=True)
+    print(f"W&B: run={run.name} id={run.id} state={run.state} url={run.url}")
+    metrics = latest_wandb_metrics(run, metric_keys)
+    if not metrics:
+        print("W&B: no requested metrics have reached run.summary yet.")
+        return
+    for key in metric_keys:
+        if key in metrics:
+            print(f"  {key}: {metrics[key]}")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Poll W&B metrics and Modal app state for a Curious training run.")
+    parser.add_argument("--entity", default=os.environ.get("WANDB_ENTITY", "autocurriculum"))
+    parser.add_argument("--project", default=os.environ.get("WANDB_PROJECT", "curious"))
+    parser.add_argument("--run-name", default=os.environ.get("RUN_NAME", "baseline-gsm8k-grpo-qwen3-0p6b-sglang-fa3-h100-seed42-v2"))
+    parser.add_argument("--model-name", default=os.environ.get("MODEL_NAME", "Qwen/Qwen3-0.6B"))
+    parser.add_argument("--generation-backend", default=os.environ.get("GENERATION_BACKEND", "sglang"))
+    parser.add_argument("--sglang-attention-backend", default=os.environ.get("SGLANG_ATTENTION_BACKEND", "fa3"))
+    parser.add_argument("--modal-app", default=os.environ.get("MODAL_APP", "curious-training"))
+    parser.add_argument("--modal-bin", default=os.environ.get("MODAL_BIN", default_modal_bin()))
+    parser.add_argument("--poll-seconds", type=float, default=float(os.environ.get("POLL_SECONDS", "60")))
+    parser.add_argument("--max-polls", type=int, default=None)
+    parser.add_argument("--metric", action="append", default=None, help="Metric key to print. Repeatable.")
+    parser.add_argument("--show-modal-logs", action="store_true")
+    parser.add_argument("--modal-log-tail", type=int, default=20)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    metric_keys = tuple(args.metric) if args.metric else DEFAULT_METRICS
+    poll_idx = 0
+
+    while args.max_polls is None or poll_idx < args.max_polls:
+        poll_idx += 1
+        print("=" * 80)
+        print(f"poll={poll_idx} time={datetime.now(timezone.utc).isoformat()}")
+        print(
+            "target="
+            f"run={args.run_name} model={args.model_name} "
+            f"backend={args.generation_backend} attention={args.sglang_attention_backend}"
+        )
+        try:
+            print_wandb_state(
+                entity=args.entity,
+                project=args.project,
+                run_name=args.run_name,
+                metric_keys=metric_keys,
+            )
+        except Exception as exc:
+            print(f"W&B polling failed: {exc}")
+
+        try:
+            print_modal_state(
+                modal_bin=args.modal_bin,
+                app_name=args.modal_app,
+                show_logs=args.show_modal_logs,
+                log_tail=args.modal_log_tail,
+            )
+        except Exception as exc:
+            print(f"Modal polling failed: {exc}")
+
+        if args.max_polls is not None and poll_idx >= args.max_polls:
+            break
+        time.sleep(args.poll_seconds)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_baseline_gsm8k_training.sh
+++ b/scripts/run_baseline_gsm8k_training.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -z "${BASH_VERSION:-}" ]; then
+  exec /usr/bin/env bash "$0" "$@"
+fi
+
+SCRIPT_SOURCE="${BASH_SOURCE[0]:-$0}"
+SCRIPT_DIR="$(cd "$(dirname "${SCRIPT_SOURCE}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${REPO_ROOT}"
+
+if [[ -z "${WANDB_API_KEY:-}" ]]; then
+  if [[ -f "${REPO_ROOT}/.env" ]]; then
+    export WANDB_API_KEY="$(
+      awk -F= '
+        function trim(s) { gsub(/^[ \t"]+|[ \t"]+$/, "", s); return s }
+        $0 ~ /^[ \t]*(export[ \t]+)?WANDB_API_KEY[ \t]*=/ {
+          sub(/^[ \t]*(export[ \t]+)?WANDB_API_KEY[ \t]*=/, "", $0)
+          print trim($0)
+          exit
+        }
+      ' "${REPO_ROOT}/.env"
+    )"
+  fi
+fi
+
+if [[ -z "${WANDB_API_KEY:-}" ]]; then
+  echo "WANDB_API_KEY not set and not found in ${REPO_ROOT}/.env"
+  echo "Export WANDB_API_KEY first, or add WANDB_API_KEY=... to .env."
+  exit 2
+fi
+
+export WANDB_API_KEY
+export TRAINING_WANDB_KEY_EXPORTED_AT="$(date -u +%s)"
+
+exec "${SCRIPT_DIR}/launch_baseline_gsm8k_grpo_modal.sh" "$@"

--- a/tests/test_ad_cispo.py
+++ b/tests/test_ad_cispo.py
@@ -168,6 +168,33 @@ def test_actor_loss_returns_raw_mean_kl_not_weighted_kl_loss():
     assert torch.allclose(mean_kl, expected_kl, atol=1e-6)
 
 
+def test_actor_loss_backprops_weighted_kl_when_advantage_is_zero():
+    log_probs = torch.tensor([[-0.9, -0.4]], requires_grad=True)
+    log_probs_ref = torch.tensor([[-0.7, -0.5]])
+    experience = Experience(
+        sequences=torch.arange(3).reshape(1, 3),
+        attention_mask=torch.ones(1, 3, dtype=torch.bool),
+        action_mask=torch.ones(1, 2, dtype=torch.bool),
+        returns=torch.tensor([0.0]),
+        solved_mask=torch.tensor([0.0]),
+        advantages=torch.tensor([0.0]),
+        action_log_probs=log_probs.detach(),
+        log_probs_ref=log_probs_ref,
+    )
+    loss_fn = ActorLoss(kl_weight=0.25)
+
+    loss, mean_kl, mean_actor_loss = loss_fn(log_probs=log_probs, experience=experience)
+    expected_weighted_kl = 0.25 * mean_kl
+
+    assert torch.allclose(mean_actor_loss, torch.zeros_like(mean_actor_loss), atol=1e-6)
+    assert torch.allclose(loss, expected_weighted_kl, atol=1e-6)
+
+    loss.backward()
+
+    assert log_probs.grad is not None
+    assert torch.count_nonzero(log_probs.grad).item() > 0
+
+
 def test_group_advantages_use_population_std_for_grpo_normalization():
     returns = torch.tensor([[1.0, 2.0, 3.0]])
 

--- a/tests/test_completion_logging.py
+++ b/tests/test_completion_logging.py
@@ -1,0 +1,66 @@
+from curious.utils.utils import (
+    build_completion_sample_rows,
+    format_completion_sample_rows,
+    log_completion_sample_table,
+)
+
+
+def test_build_completion_sample_rows_is_bounded_and_offsets_indices():
+    rows = build_completion_sample_rows(
+        phase="eval",
+        batch_idx=10,
+        questions=["q1", "q2", "q3"],
+        answers=["a1", "a2", "a3"],
+        completions=["c1", "c2", "c3"],
+        rewards=[1.0, 0.0, -1.0],
+        infos=[{"ok": True}, {"ok": False}, {"ok": False}],
+        max_samples=2,
+        sample_offset=5,
+    )
+
+    assert [row["sample_idx"] for row in rows] == [5, 6]
+    assert [row["completion"] for row in rows] == ["c1", "c2"]
+    assert rows[0]["phase"] == "eval"
+    assert rows[0]["batch_idx"] == 10
+
+
+def test_format_completion_sample_rows_uses_logging_template():
+    rows = build_completion_sample_rows(
+        phase="train",
+        batch_idx=3,
+        questions=["What is 1+1?"],
+        answers=["2"],
+        completions=["The answer is 2."],
+        rewards=[1.0],
+        infos=[{"outcome_reward": 1.0}],
+        max_samples=1,
+    )
+
+    text = format_completion_sample_rows(rows)
+
+    assert "Question:" in text
+    assert "What is 1+1?" in text
+    assert "The answer is 2." in text
+
+
+def test_log_completion_sample_table_keeps_training_step():
+    captured = []
+    rows = build_completion_sample_rows(
+        phase="train",
+        batch_idx=7,
+        questions=["q"],
+        answers=["a"],
+        completions=["c"],
+        rewards=[0.5],
+        infos=[{}],
+        max_samples=1,
+    )
+
+    log_completion_sample_table(
+        logger=captured.append,
+        key="train/completion_samples",
+        rows=rows,
+    )
+
+    assert captured[0]["num_batches_visited"] == 7
+    assert "train/completion_samples" in captured[0]

--- a/tests/test_sglang_backend.py
+++ b/tests/test_sglang_backend.py
@@ -1,0 +1,136 @@
+from pathlib import Path
+
+import torch
+from transformers import GenerationConfig
+
+from curious.sampling.sglang_backend import (
+    SGLangGenerationBackend,
+    _extract_output_token_ids,
+    build_sampled_response_tensors,
+)
+
+
+class FakeTokenizer:
+    pad_token_id = 0
+    eos_token_id = 99
+
+    def encode(self, text: str, add_special_tokens: bool = False) -> list[int]:
+        del add_special_tokens
+        return [int(token) for token in text.split()]
+
+    def save_pretrained(self, path: Path) -> None:
+        path.mkdir(parents=True, exist_ok=True)
+        (path / "tokenizer.json").write_text("{}")
+
+
+def test_build_sampled_response_tensors_aligns_actions_to_generated_tokens():
+    output = build_sampled_response_tensors(
+        tokenizer=FakeTokenizer(),
+        prompt_ids=[[11, 12, 13], [21, 22]],
+        output_token_ids=[[31, 32], [41]],
+        completions=["31 32", "41"],
+        device=torch.device("cpu"),
+    )
+
+    assert torch.equal(
+        output["sequence_ids"],
+        torch.tensor(
+            [
+                [11, 12, 13, 31, 32],
+                [21, 22, 41, 0, 0],
+            ]
+        ),
+    )
+    assert torch.equal(
+        output["action_mask"],
+        torch.tensor(
+            [
+                [False, False, True, True],
+                [False, True, False, False],
+            ]
+        ),
+    )
+    assert torch.equal(output["sequence_ids"][:, 1:][output["action_mask"]], torch.tensor([31, 32, 41]))
+
+
+def test_extract_output_token_ids_accepts_sglang_response_shapes():
+    assert _extract_output_token_ids({"output_ids": [1, 2]}) == [1, 2]
+    assert _extract_output_token_ids({"meta_info": {"output_token_ids": [3, 4]}}) == [3, 4]
+    assert _extract_output_token_ids({"text": "5 6"}) is None
+
+
+class FakeSGLangBackend(SGLangGenerationBackend):
+    def __init__(self) -> None:
+        self.tokenizer = FakeTokenizer()
+        self.requests = []
+
+    def _request(self, method: str, path: str, payload: dict | None = None):
+        self.requests.append((method, path, payload))
+        return [
+            {"text": "31", "meta_info": {"output_token_ids": [31]}},
+            {"text": "32", "output_ids": [32]},
+            {"text": "41"},
+            {"text": "42", "meta_info": {"token_ids": [42]}},
+        ]
+
+
+def test_sglang_sample_responses_replicates_trimmed_prompts_and_parses_outputs():
+    backend = FakeSGLangBackend()
+    generation_config = GenerationConfig(
+        num_return_sequences=2,
+        max_new_tokens=8,
+        temperature=0.7,
+        top_p=0.9,
+        top_k=50,
+        repetition_penalty=1.0,
+        do_sample=True,
+    )
+
+    output = backend.sample_responses(
+        batch_inputs={
+            "input_ids": torch.tensor([[0, 11, 12], [21, 22, 23]]),
+            "attention_mask": torch.tensor([[0, 1, 1], [1, 1, 1]]),
+        },
+        generation_config=generation_config,
+    )
+
+    _, _, payload = backend.requests[0]
+    assert payload["input_ids"] == [[11, 12], [11, 12], [21, 22, 23], [21, 22, 23]]
+    assert payload["sampling_params"]["stop_token_ids"] == [99]
+    assert "random_seed" not in payload["sampling_params"]
+    assert output["completions"] == ["31", "32", "41", "42"]
+    assert torch.equal(output["sequence_ids"][:, 1:][output["action_mask"]], torch.tensor([31, 32, 41, 42]))
+
+
+class FakeModel:
+    def save_pretrained(self, path: Path, safe_serialization: bool = True) -> None:
+        assert safe_serialization is True
+        path.mkdir(parents=True, exist_ok=True)
+        (path / "model.safetensors").write_text("weights")
+
+
+class FakeSyncBackend(SGLangGenerationBackend):
+    def __init__(self, weight_sync_dir: Path) -> None:
+        self.weight_sync_dir = weight_sync_dir
+        self.weight_sync_dir.mkdir(parents=True, exist_ok=True)
+        self._last_synced_path = None
+        self.requests = []
+
+    def _request(self, method: str, path: str, payload: dict | None = None):
+        self.requests.append((method, path, payload))
+        return {"success": True}
+
+
+def test_sglang_weight_sync_uses_disk_schema_and_keeps_only_latest_dir(tmp_path):
+    backend = FakeSyncBackend(tmp_path)
+
+    backend.sync_weights_from_model(FakeModel(), FakeTokenizer(), step=1)
+    first_path = tmp_path / "step_00000001"
+    assert backend.requests[-1] == ("POST", "/update_weights_from_disk", {"model_path": str(first_path)})
+    assert first_path.exists()
+
+    backend.sync_weights_from_model(FakeModel(), FakeTokenizer(), step=2)
+    second_path = tmp_path / "step_00000002"
+    assert backend.requests[-1] == ("POST", "/update_weights_from_disk", {"model_path": str(second_path)})
+    assert not first_path.exists()
+    assert second_path.exists()

--- a/tests/test_training_setup.py
+++ b/tests/test_training_setup.py
@@ -1,0 +1,20 @@
+from curious.config import RLConfig
+from curious.train.training_setup import needs_reference_policy
+
+
+def test_zero_kl_grpo_without_ad_cispo_does_not_need_reference_policy():
+    rl_config = RLConfig(kl_weight=0.0, use_ad_cispo=False)
+
+    assert not needs_reference_policy(rl_config)
+
+
+def test_kl_regularization_needs_reference_policy():
+    rl_config = RLConfig(kl_weight=0.01, use_ad_cispo=False)
+
+    assert needs_reference_policy(rl_config)
+
+
+def test_ad_cispo_needs_reference_policy_even_without_kl_regularization():
+    rl_config = RLConfig(kl_weight=0.0, use_ad_cispo=True)
+
+    assert needs_reference_policy(rl_config)

--- a/uv.lock
+++ b/uv.lock
@@ -165,15 +165,6 @@ wheels = [
 ]
 
 [[package]]
-name = "astor"
-version = "0.8.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5a/21/75b771132fee241dfe601d39ade629548a9626d1d39f333fde31bc46febe/astor-0.8.1.tar.gz", hash = "sha256:6a6effda93f4e1ce9f618779b2dd1d9d84f1e32812c23a29b3fff6fd7f63fa5e", size = 35090 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c3/88/97eef84f48fa04fbd6750e62dcceafba6c63c81b7ac1420856c8dcc0a3f9/astor-0.8.1-py2.py3-none-any.whl", hash = "sha256:070a54e890cefb5b3739d19f30f5a5ec840ffc9c50ffa7d23cc9fc1a38ebbfc5", size = 27488 },
-]
-
-[[package]]
 name = "asttokens"
 version = "3.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -192,33 +183,18 @@ wheels = [
 ]
 
 [[package]]
-name = "blake3"
-version = "1.0.8"
+name = "blobfile"
+version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.12' and sys_platform == 'linux'" },
+    { name = "filelock", marker = "sys_platform == 'linux'" },
+    { name = "lxml", marker = "sys_platform == 'linux'" },
+    { name = "pycryptodomex", marker = "sys_platform == 'linux'" },
+    { name = "urllib3", marker = "sys_platform == 'linux'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/75/aa/abcd75e9600987a0bc6cfe9b6b2ff3f0e2cb08c170addc6e76035b5c4cb3/blake3-1.0.8.tar.gz", hash = "sha256:513cc7f0f5a7c035812604c2c852a0c1468311345573de647e310aca4ab165ba", size = 117308 }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/a9/a34e8153b0203d9060ff7aa5dfcd175e161117949697a83c4cc003b523ff/blobfile-3.0.0.tar.gz", hash = "sha256:32ec777414de7bb2a76ca812a838f0d33327ca28ae844a253503cde625cdf2f1", size = 77863 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/33/9d342a2bf5817f006bbe947335e5d387327541ea47590854947befd01251/blake3-1.0.8-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:58ce8d45a5bb5326482de72ea1969a378634236186a970fef63058a5b7b8b435", size = 374859 },
-    { url = "https://files.pythonhosted.org/packages/a5/67/167a65a4c431715407d07b1b8b1367698a3ad88e7260edb85f0c5293f08a/blake3-1.0.8-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3b5573b052777142b2cecc453d022c3f21aa4aba75011258410bb98f41c1a727", size = 507519 },
-    { url = "https://files.pythonhosted.org/packages/32/e2/0886e192d634b264c613b0fbf380745b39992b424a0effc00ef08783644e/blake3-1.0.8-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:fe1b02ab49bfd969ef50b9f17482a2011c77536654af21807ba5c2674e0bb2a0", size = 393645 },
-    { url = "https://files.pythonhosted.org/packages/fc/3b/7fb2fe615448caaa5f6632b2c7551117b38ccac747a3a5769181e9751641/blake3-1.0.8-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c7780666dc6be809b49442d6d5ce06fdbe33024a87560b58471103ec17644682", size = 387640 },
-    { url = "https://files.pythonhosted.org/packages/7e/75/0252be37620699b79dbaa799c9b402d63142a131d16731df4ef09d135dd7/blake3-1.0.8-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:c63ece266a43014cf29e772a82857cd8e90315ae3ed53e3c5204851596edd5f2", size = 554463 },
-    { url = "https://files.pythonhosted.org/packages/e3/20/488475254976ed93fab57c67aa80d3b40df77f7d9db6528c9274bff53e08/blake3-1.0.8-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:66ca28a673025c40db3eba21a9cac52f559f83637efa675b3f6bd8683f0415f3", size = 374516 },
-    { url = "https://files.pythonhosted.org/packages/cb/7d/db0626df16029713e7e61b67314c4835e85c296d82bd907c21c6ea271da2/blake3-1.0.8-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e5b5da177d62cc4b7edf0cea08fe4dec960c9ac27f916131efa890a01f747b93", size = 505420 },
-    { url = "https://files.pythonhosted.org/packages/5b/55/6e737850c2d58a6d9de8a76dad2ae0f75b852a23eb4ecb07a0b165e6e436/blake3-1.0.8-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:38209b10482c97e151681ea3e91cc7141f56adbbf4820a7d701a923124b41e6a", size = 394189 },
-    { url = "https://files.pythonhosted.org/packages/5b/94/eafaa5cdddadc0c9c603a6a6d8339433475e1a9f60c8bb9c2eed2d8736b6/blake3-1.0.8-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:504d1399b7fb91dfe5c25722d2807990493185faa1917456455480c36867adb5", size = 388001 },
-    { url = "https://files.pythonhosted.org/packages/0e/c6/d1fe8bdea4a6088bd54b5a58bc40aed89a4e784cd796af7722a06f74bae7/blake3-1.0.8-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:a25db3d36b55f5ed6a86470155cc749fc9c5b91c949b8d14f48658f9d960d9ec", size = 554211 },
-]
-
-[[package]]
-name = "cachetools"
-version = "7.1.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f4/8b/0d3945a13955303b81272f759a0331e54c5c793da455e6f5706b89d2639c/cachetools-7.1.4.tar.gz", hash = "sha256:437f55a4e0c1b01a4f3077cc470e6991d47430970e36fbcb77e2be0df4fc1cd6", size = 40085 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8c/7b/1fc1c09cc0756cf25861a3be10565915953876da48bb228fb9a672b20a42/cachetools-7.1.4-py3-none-any.whl", hash = "sha256:323dc4127934744db5b54eb4924482d7edafbf9554e820d1531c2e08c0e4ef54", size = 16761 },
+    { url = "https://files.pythonhosted.org/packages/ed/4d/1392562369b1139e741b30d624f09fe7091d17dd5579fae5732f044b12bb/blobfile-3.0.0-py3-none-any.whl", hash = "sha256:48ecc3307e622804bd8fe13bf6f40e6463c4439eba7a1f9ad49fd78aa63cc658", size = 75413 },
 ]
 
 [[package]]
@@ -385,6 +361,31 @@ wheels = [
 ]
 
 [[package]]
+name = "cuda-bindings"
+version = "13.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cuda-pathfinder", marker = "sys_platform == 'linux'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/7a/c5e3c34a409b148f5c0f5a4ea374158f95d488862c1dffedf9aa5c639df9/cuda_bindings-13.3.1-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:04436a9364059c84b8f9636f359eccda1cf814341f5b670c71d80d2f79dbc708", size = 6674166 },
+    { url = "https://files.pythonhosted.org/packages/39/2a/6d2e9047d1fb243dbaa364b01e0297534b9ed7fd27dba1c9f361519cf69b/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e32d08f71ebcdf00f0f41eab2eb37e8da94c8ed411cc9f7f7a019ce6b34abe3a", size = 6657965 },
+]
+
+[[package]]
+name = "cuda-core"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cuda-pathfinder", marker = "sys_platform == 'linux'" },
+    { name = "numpy", marker = "sys_platform == 'linux'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/55/bb3e701f4af504e5e39e837135dc80022ec4c84858b2886ad577fe696a77/cuda_core-1.0.1-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1934517ff8a9dcd21b3f4a28e15e12643164b7d3ec187a4ee7560e22fd2dfc17", size = 5059041 },
+    { url = "https://files.pythonhosted.org/packages/a1/4d/603557ab3cb171cc2a61d3678a39cb4dae3fd21275078bfbd1c0b0b5230b/cuda_core-1.0.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:be7b65311bf78964b7905adbf3c0f8f717d432f2854dc45169277729bf60f1e2", size = 5106023 },
+]
+
+[[package]]
 name = "cuda-pathfinder"
 version = "1.5.5"
 source = { registry = "https://pypi.org/simple" }
@@ -393,16 +394,16 @@ wheels = [
 ]
 
 [[package]]
-name = "cupy-cuda12x"
-version = "14.1.1"
+name = "cuda-python"
+version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "cuda-bindings", marker = "sys_platform == 'linux'" },
+    { name = "cuda-core", marker = "sys_platform == 'linux'" },
     { name = "cuda-pathfinder", marker = "sys_platform == 'linux'" },
-    { name = "numpy", marker = "sys_platform == 'linux'" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dd/5e/ccd2fea320ece269dd7237649da384cad71fbb1ba30937a1eb3311c31b77/cupy_cuda12x-14.1.1-cp311-cp311-manylinux2014_x86_64.whl", hash = "sha256:8889cb83dbb7dbea593e60c85fcc91e21b0ccd10cd5380dfdfaac70b6bd9390a", size = 134012855 },
-    { url = "https://files.pythonhosted.org/packages/f6/6e/dc03c1ddc940f33b3d32803898e2fdae5c9538a2127a25f499494c84b183/cupy_cuda12x-14.1.1-cp312-cp312-manylinux2014_x86_64.whl", hash = "sha256:a1138f20080489a46209291498cd12f792226d0a57d50c64a586c162a875a069", size = 133516927 },
+    { url = "https://files.pythonhosted.org/packages/38/31/7ff3f7768eded7535c621abc2fecb9d181a34ea4cae3afe682feb796f242/cuda_python-13.3.1-py3-none-any.whl", hash = "sha256:280b014139ab447b6dd70a377db1596f310d6e887d9d342e6651b919ec145fb3", size = 8295 },
 ]
 
 [[package]]
@@ -412,15 +413,14 @@ source = { virtual = "." }
 dependencies = [
     { name = "accelerate" },
     { name = "datasets" },
-    { name = "deepspeed", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "diff-parser" },
     { name = "liger-kernel", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "math-verify" },
     { name = "memory-profiler" },
     { name = "modal" },
-    { name = "mpi4py", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "python-dotenv" },
     { name = "setuptools" },
+    { name = "sglang", extra = ["srt"], marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "toml" },
     { name = "torch" },
     { name = "transformers" },
@@ -428,7 +428,6 @@ dependencies = [
     { name = "trl" },
     { name = "tyro" },
     { name = "unidiff" },
-    { name = "vllm", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "wandb" },
 ]
 
@@ -441,24 +440,22 @@ dev = [
 requires-dist = [
     { name = "accelerate", specifier = "==1.6.0" },
     { name = "datasets", specifier = "==3.5.0" },
-    { name = "deepspeed", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'", specifier = "==0.16.7" },
     { name = "diff-parser", specifier = "==1.1" },
     { name = "liger-kernel", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'", specifier = "==0.5.8" },
     { name = "math-verify", specifier = "==0.7.0" },
     { name = "memory-profiler", specifier = "==0.61.0" },
     { name = "modal", specifier = "==1.4.3" },
-    { name = "mpi4py", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'", specifier = "==4.0.3" },
     { name = "python-dotenv", specifier = "==1.1.0" },
     { name = "setuptools", specifier = "==76.1.0" },
+    { name = "sglang", extras = ["srt"], marker = "platform_machine == 'x86_64' and sys_platform == 'linux'", specifier = "==0.4.6.post5" },
     { name = "toml", specifier = "==0.10.2" },
     { name = "torch", specifier = "==2.6.0" },
-    { name = "transformers", specifier = "==4.51.3" },
+    { name = "transformers", specifier = "==4.51.1" },
     { name = "tree-sitter", specifier = "==0.24.0" },
     { name = "trl", specifier = "==0.16.1" },
     { name = "tyro", specifier = "==0.9.18" },
     { name = "unidiff", specifier = "==0.7.5" },
-    { name = "vllm", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'", specifier = "==0.8.4" },
-    { name = "wandb", specifier = "==0.19.9" },
+    { name = "wandb", specifier = "==0.27.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -516,59 +513,6 @@ wheels = [
 ]
 
 [[package]]
-name = "deepspeed"
-version = "0.16.7"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "einops", marker = "sys_platform == 'linux'" },
-    { name = "hjson", marker = "sys_platform == 'linux'" },
-    { name = "msgpack", marker = "sys_platform == 'linux'" },
-    { name = "ninja", marker = "sys_platform == 'linux'" },
-    { name = "numpy", marker = "sys_platform == 'linux'" },
-    { name = "packaging", marker = "sys_platform == 'linux'" },
-    { name = "psutil", marker = "sys_platform == 'linux'" },
-    { name = "py-cpuinfo", marker = "sys_platform == 'linux'" },
-    { name = "pydantic", marker = "sys_platform == 'linux'" },
-    { name = "torch", marker = "sys_platform == 'linux'" },
-    { name = "tqdm", marker = "sys_platform == 'linux'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/06/b3/a3903de5c5b707170c5c27e1a40f4ef613f14d241bd84d8b151a2a8786f6/deepspeed-0.16.7.tar.gz", hash = "sha256:2a56eee6ad7b82decf37bb6ad8ec5e16dad96b647d79854132c715d42a78bd85", size = 1511314 }
-
-[[package]]
-name = "deprecated"
-version = "1.3.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "wrapt", marker = "sys_platform == 'linux'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/49/85/12f0a49a7c4ffb70572b6c2ef13c90c88fd190debda93b23f026b25f9634/deprecated-1.3.1.tar.gz", hash = "sha256:b1b50e0ff0c1fddaa5708a2c6b0a6588bb09b892825ab2b214ac9ea9d92a5223", size = 2932523 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl", hash = "sha256:597bfef186b6f60181535a29fbe44865ce137a5079f295b479886c82729d5f3f", size = 11298 },
-]
-
-[[package]]
-name = "depyf"
-version = "0.18.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "astor", marker = "sys_platform == 'linux'" },
-    { name = "dill", marker = "sys_platform == 'linux'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f9/ee/43a4cbba615abfc1eb2e5ff5eed3f80f38d58645b4d13d0ea06b9ca1909d/depyf-0.18.0.tar.gz", hash = "sha256:b99f0c383be949ae45d5d606fe444c71f375b55a57b8d6b20e7856670d52130d", size = 43050 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e7/d8/efc291d5c69a9905515055d23977643dd0d482ebfeb0dbabef1947ee75d8/depyf-0.18.0-py3-none-any.whl", hash = "sha256:007294d5bac19a38a0767d747be0f49b9ffdcea0394a822644142df22b33a3e1", size = 38839 },
-]
-
-[[package]]
-name = "detect-installer"
-version = "0.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5f/ce/6897d812825e9d4c53e3c7112726e800cc5231b013b2223bf64f653ff362/detect_installer-0.1.0.tar.gz", hash = "sha256:00ad7ba0a36e3cf7d08a40d3643011746dbc112597c7d475cc91c416710ca4e7", size = 3049 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/34/8cc73273414405086c58852916e4031812a6a30fe04c057e37ad99397b7f/detect_installer-0.1.0-py3-none-any.whl", hash = "sha256:034fb20fd665c36e6ba52b8821525ea07fb4f7f938cac459df889fb33801528a", size = 4539 },
-]
-
-[[package]]
 name = "diff-parser"
 version = "1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -596,36 +540,6 @@ wheels = [
 ]
 
 [[package]]
-name = "distro"
-version = "1.9.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277 },
-]
-
-[[package]]
-name = "dnspython"
-version = "2.8.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094 },
-]
-
-[[package]]
-name = "docker-pycreds"
-version = "0.4.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c5/e6/d1f6c00b7221e2d7c4b470132c931325c8b22c51ca62417e300f5ce16009/docker-pycreds-0.4.0.tar.gz", hash = "sha256:6ce3270bcaf404cc4c3e27e4b6c70d3521deae82fb508767870fdbf772d584d4", size = 8754 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f5/e8/f6bd1eee09314e7e6dee49cbe2c5e22314ccdb38db16c9fc72d2fa80d054/docker_pycreds-0.4.0-py2.py3-none-any.whl", hash = "sha256:7266112468627868005106ec19cd0d722702d2b7d5912a28e19b826c3d37af49", size = 8982 },
-]
-
-[[package]]
 name = "docstring-parser"
 version = "0.18.0"
 source = { registry = "https://pypi.org/simple" }
@@ -641,19 +555,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/2c/77/850bef8d72ffb9219f0b1aac23fbc1bf7d038ee6ea666f331fa273031aa2/einops-0.8.2.tar.gz", hash = "sha256:609da665570e5e265e27283aab09e7f279ade90c4f01bcfca111f3d3e13f2827", size = 56261 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/09/f8d8f8f31e4483c10a906437b4ce31bdf3d6d417b73fe33f1a8b59e34228/einops-0.8.2-py3-none-any.whl", hash = "sha256:54058201ac7087911181bfec4af6091bb59380360f069276601256a76af08193", size = 65638 },
-]
-
-[[package]]
-name = "email-validator"
-version = "2.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "dnspython", marker = "sys_platform == 'linux'" },
-    { name = "idna", marker = "sys_platform == 'linux'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/15/545e2b6cf2e3be84bc1ed85613edd75b8aea69807a71c26f4ca6a9258e82/email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4", size = 35604 },
 ]
 
 [[package]]
@@ -681,88 +582,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/82/45359b62a067409bd929ae8a56b8ed13e5a8c8a61194b3c236920999ab83/fastapi-0.136.3-py3-none-any.whl", hash = "sha256:3d2a69bdf04b7e9f3afa292c3bc7a98816bbfafa10bc9b45f3f3700d2f761620", size = 117481 },
 ]
 
-[package.optional-dependencies]
-standard = [
-    { name = "email-validator", marker = "sys_platform == 'linux'" },
-    { name = "fastapi-cli", extra = ["standard"], marker = "sys_platform == 'linux'" },
-    { name = "fastar", marker = "sys_platform == 'linux'" },
-    { name = "httpx", marker = "sys_platform == 'linux'" },
-    { name = "jinja2", marker = "sys_platform == 'linux'" },
-    { name = "pydantic-extra-types", marker = "sys_platform == 'linux'" },
-    { name = "pydantic-settings", marker = "sys_platform == 'linux'" },
-    { name = "python-multipart", marker = "sys_platform == 'linux'" },
-    { name = "uvicorn", extra = ["standard"], marker = "sys_platform == 'linux'" },
-]
-
-[[package]]
-name = "fastapi-cli"
-version = "0.0.24"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "rich-toolkit", marker = "sys_platform == 'linux'" },
-    { name = "typer", marker = "sys_platform == 'linux'" },
-    { name = "uvicorn", extra = ["standard"], marker = "sys_platform == 'linux'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/6e/58/74797ae9e4610cfa0c6b34c8309096d3b20bb29be3b8b5fbf1004d10fa5f/fastapi_cli-0.0.24.tar.gz", hash = "sha256:1afc9c9e21d7ebc8a3ca5e31790cd8d837742be7e4f8b9236e99cb3451f0de00", size = 19043 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/4b/68f9fe268e535d79c76910519530026a4f994ce07189ac0dded45c6af825/fastapi_cli-0.0.24-py3-none-any.whl", hash = "sha256:4a1f78ed798f106b4fee85ca93b85d8fe33c0a3570f775964d37edb80b8f0edc", size = 12304 },
-]
-
-[package.optional-dependencies]
-standard = [
-    { name = "fastapi-cloud-cli", marker = "sys_platform == 'linux'" },
-    { name = "uvicorn", extra = ["standard"], marker = "sys_platform == 'linux'" },
-]
-
-[[package]]
-name = "fastapi-cloud-cli"
-version = "0.19.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "detect-installer", marker = "sys_platform == 'linux'" },
-    { name = "fastar", marker = "sys_platform == 'linux'" },
-    { name = "httpx", marker = "sys_platform == 'linux'" },
-    { name = "pydantic", extra = ["email"], marker = "sys_platform == 'linux'" },
-    { name = "rich-toolkit", marker = "sys_platform == 'linux'" },
-    { name = "rignore", marker = "sys_platform == 'linux'" },
-    { name = "sentry-sdk", marker = "sys_platform == 'linux'" },
-    { name = "typer", marker = "sys_platform == 'linux'" },
-    { name = "uvicorn", extra = ["standard"], marker = "sys_platform == 'linux'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a7/7c/f194925af8fabdb0b7a886a1b89087c0b7f327f99e79497a882aa94c1e34/fastapi_cloud_cli-0.19.0.tar.gz", hash = "sha256:f97b31c2ad6af3832eb4065870bdca3365b6e827a0ccf6eeb15e477bc1662b13", size = 57476 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/bf/e6/1a2ec890fc273b9da2b173ca45f692a2e24a369bdd39ea7812c1d8a799e5/fastapi_cloud_cli-0.19.0-py3-none-any.whl", hash = "sha256:a2dfc4074c321e63ec88589cc1f90573d4b5bf980ddc44a7033e6f3cd8e96628", size = 38239 },
-]
-
-[[package]]
-name = "fastar"
-version = "0.11.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/03/0f/0aeb3fc50046617702acc0078b277b58367fd62eb727b9ec733ae0e8bbcc/fastar-0.11.0.tar.gz", hash = "sha256:aa7f100f7313c03fdb20f1385927ba95671071ba308ad0c1763fef295e1895ce", size = 70238 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/cc/5491e2b677bb841f768e3aba052d0344338a5c78aa5d4c18b443831a8e8d/fastar-0.11.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5b83c1f61f7017d6e1498568038f8745440cfc16ca2f697ec81bac83050108f6", size = 759232 },
-    { url = "https://files.pythonhosted.org/packages/4e/b7/643630bdbd179e41e9fae31c03b4cf6061dbf4d6fbbae8425d16eb12545d/fastar-0.11.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:db73a9b765a516e73983b25341e7b5e0189733878279e278b2295131b0e3a21e", size = 926271 },
-    { url = "https://files.pythonhosted.org/packages/09/5d/37ade50003b4540e0a53ef100f6692d7ab2ac1122d5acf39920cc09a3e8b/fastar-0.11.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:625827d52eb4e8fec942e0233f125ff8010fcf6a67c0a974a8e5f4666b771e3c", size = 818634 },
-    { url = "https://files.pythonhosted.org/packages/c3/ff/135d177de32cc1e837c99019e4643e6e79352bde49544d4ece5b5eebf56b/fastar-0.11.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d7f5fd8fa21ec0a88296a38dc5d7fc35efd3b26d46a17b8b7c73c5563925ca15", size = 822755 },
-    { url = "https://files.pythonhosted.org/packages/27/cb/b835dbe76ceac7fa6105851468c259ffd06830eb9c029402e499d0ec153b/fastar-0.11.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:8c15af91b8cd87ddf23ea55355ae513c1de3ab67178f26dad017c9e9c0af6096", size = 887101 },
-    { url = "https://files.pythonhosted.org/packages/1f/fd/776d50a0897c01dc6bfd0926772ee913436fdae91b9affaf0a0cbd09f0a1/fastar-0.11.0-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:f2994bb8f5f8c11eb12beae1e6e77a907173c9819236b8a4c8f0573652ceccce", size = 1036696 },
-    { url = "https://files.pythonhosted.org/packages/f8/9e/21e4701aec4a1123d4dc4d31578dc18875582b5710e4725f7ceb752a248b/fastar-0.11.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:29c9c386dc0d5dda78845a8e6b1480d26ab861c1e0b68f42ae5735cb70ca07f1", size = 1032336 },
-    { url = "https://files.pythonhosted.org/packages/2f/a6/82ef4ecd969d50d92ed3ed9dbd8fe77faa24be5e5736f716edc9f4ce8d62/fastar-0.11.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:38ef77fe940bbc9b37a98bd838727f844b11731cd39358a2640ff864fb385086", size = 757603 },
-    { url = "https://files.pythonhosted.org/packages/03/35/50249f0d827251f8ac511495e2eacccebda80a00a0ad73e9615b8113b84f/fastar-0.11.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8955e61b32d6aff82c983217abf80933fd823b0e727586fc72f08043d996fd59", size = 923952 },
-    { url = "https://files.pythonhosted.org/packages/7b/d8/faee41659e9c379d906d24eaee6d6833ac8cfef0a5df480e5c2a8d3efb33/fastar-0.11.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:483532442cdb08fbff0169510224eae0836f2f672cea6aacb52847d90fefdc46", size = 816574 },
-    { url = "https://files.pythonhosted.org/packages/22/47/0448ea7992b997dad2bf004bfd98eca74b5858630eae080b50c7b17d9ddc/fastar-0.11.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ef5a6071121e05d8287fc75bccb054bcbac8bb0501200a0c0a8feeace5303ea4", size = 819382 },
-    { url = "https://files.pythonhosted.org/packages/33/ef/0d63eb43586831b7a6f8b22c4d77125a7c594423af1f4f090fa9541b9b40/fastar-0.11.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:e45e598af5afe8412197d4786efd6cf29be02e7d3d4f6a3461149eae5d7e94f1", size = 885254 },
-    { url = "https://files.pythonhosted.org/packages/a5/37/e8bb24f506ba2b08fbaf36c5800e843bd4d542954e9331f00418e2d23349/fastar-0.11.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:4bb4dc0fc8f7a6807febcebce8a2f3626ba4955a9263d81ecc630aad83be84c0", size = 1035185 },
-    { url = "https://files.pythonhosted.org/packages/d2/cd/a81c1aaafb5a22ce57c98ae22f39c89413ed53e4ee6e1b1444b0bd666a6c/fastar-0.11.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:136cf342735464091c39dc3708168f9fdeb9ebea40b1ead937c61afaf46143d9", size = 1028054 },
-    { url = "https://files.pythonhosted.org/packages/99/e3/74d6859e632e8fb9339a14f652fb9f800c2bd6aa53071e311c0be3fbab8b/fastar-0.11.0-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:878eaf15463eb572e3538af7ca3a8534e5e279cf8196db902d24e5725c4af86e", size = 761375 },
-    { url = "https://files.pythonhosted.org/packages/a3/e7/cc70e2be5ef8731a7525552b1c35c1448cf9eae6a62cb3a56f12c1bf27ea/fastar-0.11.0-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0324ed1d1ef0186e1bbd843b17807d6d837d0906899d4c99378b02c5d86bdd9c", size = 928189 },
-    { url = "https://files.pythonhosted.org/packages/3c/33/c9a969e78dca323547276a6fee5f4f9588f7cd5ab45acec3778c67399589/fastar-0.11.0-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bdf9bd863205590beaf8ef6e66f315310196632180dceaf674985d01a876cac3", size = 820864 },
-    { url = "https://files.pythonhosted.org/packages/84/bd/6b9434b541fe55c125b5f2e017a565596a2d215aa09207e4555e4585064f/fastar-0.11.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:59af8dbb683b24b90fb5b506de080faeab0a17a908e6c2a5d93a97260ed75d7b", size = 824060 },
-    { url = "https://files.pythonhosted.org/packages/24/8d/871d5f8cf4c6f13987119fb0a9ae8be131e34f2756c2524e9974adf33824/fastar-0.11.0-pp311-pypy311_pp73-manylinux_2_31_riscv64.whl", hash = "sha256:9f3df73a3c4292cfe15696cdf59cdb6c309ab59d30b34c733be13c6e32d9a264", size = 889217 },
-    { url = "https://files.pythonhosted.org/packages/99/94/8bbb0b13f5b6cbe2492f0b7cbba5103e6163976a3331466d010e781fa189/fastar-0.11.0-pp311-pypy311_pp73-musllinux_1_2_armv7l.whl", hash = "sha256:a8c7bc8ac74cb359bb546b199288c83236372d094b402e557c197e85527495cd", size = 1038492 },
-    { url = "https://files.pythonhosted.org/packages/ec/6d/56ef943ea524784598c035ccbd42e564e937da0438ae3f55f0e76cb95571/fastar-0.11.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:6a1c56957ac82408be37a3f63594bc83e0919e8760492a4475e542f9f1828778", size = 1034886 },
-]
-
 [[package]]
 name = "filelock"
 version = "3.29.0"
@@ -771,6 +590,17 @@ sdist = { url = "https://files.pythonhosted.org/packages/b5/fe/997687a931ab51049
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/47/dd9a212ef6e343a6857485ffe25bba537304f1913bdbed446a23f7f592e1/filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258", size = 39812 },
 ]
+
+[[package]]
+name = "flashinfer-python"
+version = "0.2.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ninja", marker = "sys_platform == 'linux'" },
+    { name = "numpy", marker = "sys_platform == 'linux'" },
+    { name = "torch", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b2/c4/9ec0f79e2480fc5c93307c4a1ac903e5cf33c551c0eaeb648196234b55af/flashinfer_python-0.2.5.tar.gz", hash = "sha256:990aa090ef781783e76b836696ece4efd23956f72b5696d622fc619a61162aef", size = 2492267 }
 
 [[package]]
 name = "frozenlist"
@@ -828,21 +658,6 @@ http = [
 ]
 
 [[package]]
-name = "gguf"
-version = "0.19.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy", marker = "sys_platform == 'linux'" },
-    { name = "pyyaml", marker = "sys_platform == 'linux'" },
-    { name = "requests", marker = "sys_platform == 'linux'" },
-    { name = "tqdm", marker = "sys_platform == 'linux'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/48/ae/17f1308ae45cd7b08ebb521747d5b23f4efc4d172038a4e228dd5106c3ff/gguf-0.19.0.tar.gz", hash = "sha256:dbadcd6cc7ccd44256f2229fe7c2dff5e8aa5cf0612ab987fd2b1a57e428923f", size = 111220 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b3/bb/d71d6da82763528c2c2ed6b59a9d6142c6595545a4c448e2085d155e88c2/gguf-0.19.0-py3-none-any.whl", hash = "sha256:70bcd10edfe697fb2dad6e40af2234b9d8ece9a41a99761405121ebda1c3c1cd", size = 118475 },
-]
-
-[[package]]
 name = "gitdb"
 version = "4.0.12"
 source = { registry = "https://pypi.org/simple" }
@@ -864,35 +679,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/33/f6/354ae6491228b5eb40e10d89c4d13c651fe1cf7556e35ebdded50cff57ce/gitpython-3.1.50.tar.gz", hash = "sha256:80da2d12504d52e1f998772dc5baf6e553f8d2fcfe1fcc226c9d9a2ee3372dcc", size = 219798 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/7a/1c6e3562dfd8950adbb11ffbc65d21e7c89d01a6e4f137fa981056de25c5/gitpython-3.1.50-py3-none-any.whl", hash = "sha256:d352abe2908d07355014abdd21ddf798c2a961469239afec4962e9da884858f9", size = 212507 },
-]
-
-[[package]]
-name = "googleapis-common-protos"
-version = "1.75.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "protobuf", marker = "sys_platform == 'linux'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b5/c8/f439cffde755cffa462bfbb156278fa6f9d09119719af9814b858fd4f81f/googleapis_common_protos-1.75.0.tar.gz", hash = "sha256:53a062ff3c32552fbd62c11fe23768b78e4ddf0494d5e5fd97d3f4689c75fbbd", size = 151035 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e7/c8/e2645aa8ed02fd4c7a2f59d68783b65b1f3cbdfe39a6308e156509d1fee8/googleapis_common_protos-1.75.0-py3-none-any.whl", hash = "sha256:961ed60399c457ceb0ee8f285a84c870aabc9c6a832b9d37bb281b5bebde43ed", size = 300631 },
-]
-
-[[package]]
-name = "grpcio"
-version = "1.81.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions", marker = "sys_platform == 'linux'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/15/f3/23f47b24f8d8c2028eba501db3acfbb2f592cbb5995eaa6e363a627b74d7/grpcio-1.81.0.tar.gz", hash = "sha256:a5acd7efd3b1fe9b4eb0bcaaa1507eed68a0ad0678b654c3f7b464df9ba9dca5", size = 13032272 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/45/a8/9916ab10a0201f4c7afb6918125aa2f38a7626ee18ffbc066dd9cb04a74d/grpcio-1.81.0-cp311-cp311-linux_armv7l.whl", hash = "sha256:794e6aa648e8df47d8f908dc8c3b42347d04ec58438f1dcd4e445f09b4f6b0ce", size = 6093557 },
-    { url = "https://files.pythonhosted.org/packages/f4/18/7c8e3d0dda2fb7a17076fcd6c9085209eabad3354696c64230f87b3a14eb/grpcio-1.81.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:dbdb99986548a7e87f8343805ef315fd4eb50ffaabf4fb1206e42f2542bb805d", size = 6842564 },
-    { url = "https://files.pythonhosted.org/packages/e5/20/0e7ea7494955cf1beea3077b2fd2c04c84d4480c2ae85a1e1cfa150c62d7/grpcio-1.81.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:77eb4e9fe61486bd1198cc7236ebb0f70e66234e63c0348f40bc2553ed16a88b", size = 7873958 },
-    { url = "https://files.pythonhosted.org/packages/82/d5/896a3aaf07068d707d88b282a04914b872db4d32d3c7e6d88e43a3b911fa/grpcio-1.81.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:57b3b0e73a518fa286959b40c3eddd02703504ca186e8b7b2945954519bd8b2c", size = 6053538 },
-    { url = "https://files.pythonhosted.org/packages/e2/98/1f3896a9baae1f2aedf4e99c55291d6fa1f30ad9603d63bc18bda967b53e/grpcio-1.81.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:19f201da7b4e5c0559198abe5a97157e726f3abe6e8f5e832d4a50740f6dcc22", size = 6809676 },
-    { url = "https://files.pythonhosted.org/packages/5c/73/3860341e6a1f5347be6ab35c6c0e1e3a8eb59d010388207fd561dcf01a88/grpcio-1.81.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c6ff087cb1f563f47b504b4e29e684129fc5ae4863faf3ebca08a327764ee6cb", size = 7849498 },
 ]
 
 [[package]]
@@ -931,6 +717,19 @@ wheels = [
 ]
 
 [[package]]
+name = "hf-transfer"
+version = "0.1.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/eb/8fc64f40388c29ce8ce3b2b180a089d4d6b25b1d0d232d016704cb852104/hf_transfer-0.1.9.tar.gz", hash = "sha256:035572865dab29d17e783fbf1e84cf1cb24f3fcf8f1b17db1cfc7fdf139f02bf", size = 25201 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f6/2e/a072cf196edfeda3310c9a5ade0a0fdd785e6154b3ce24fc738c818da2a7/hf_transfer-0.1.9-cp38-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ee8b10afedcb75f71091bcc197c526a6ebf5c58bbbadb34fdeee6160f55f619f", size = 3064995 },
+    { url = "https://files.pythonhosted.org/packages/29/63/b560d39651a56603d64f1a0212d0472a44cbd965db2fa62b99d99cb981bf/hf_transfer-0.1.9-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fc6bd19e1cc177c66bdef15ef8636ad3bde79d5a4f608c158021153b4573509d", size = 3400839 },
+    { url = "https://files.pythonhosted.org/packages/d6/d8/f87ea6f42456254b48915970ed98e993110521e9263472840174d32c880d/hf_transfer-0.1.9-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cdca9bfb89e6f8f281890cc61a8aff2d3cecaff7e1a4d275574d96ca70098557", size = 3552664 },
+    { url = "https://files.pythonhosted.org/packages/82/1a/9c748befbe3decf7cb415e34f8a0c3789a0a9c55910dea73d581e48c0ce5/hf_transfer-0.1.9-cp38-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:dc7fff1345980d6c0ebb92c811d24afa4b98b3e07ed070c8e38cc91fd80478c5", size = 3390096 },
+    { url = "https://files.pythonhosted.org/packages/e7/6e/e597b04f753f1b09e6893075d53a82a30c13855cbaa791402695b01e369f/hf_transfer-0.1.9-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:d2fde99d502093ade3ab1b53f80da18480e9902aa960dab7f74fb1b9e5bc5746", size = 3695243 },
+]
+
+[[package]]
 name = "hf-xet"
 version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -947,61 +746,12 @@ wheels = [
 ]
 
 [[package]]
-name = "hjson"
-version = "3.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/e5/0b56d723a76ca67abadbf7fb71609fb0ea7e6926e94fcca6c65a85b36a0e/hjson-3.1.0.tar.gz", hash = "sha256:55af475a27cf83a7969c808399d7bccdec8fb836a07ddbd574587593b9cdcf75", size = 40541 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1f/7f/13cd798d180af4bf4c0ceddeefba2b864a63c71645abc0308b768d67bb81/hjson-3.1.0-py3-none-any.whl", hash = "sha256:65713cdcf13214fb554eb8b4ef803419733f4f5e551047c9b711098ab7186b89", size = 54018 },
-]
-
-[[package]]
 name = "hpack"
 version = "4.1.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/2c/48/71de9ed269fdae9c8057e5a4c0aa7402e8bb16f2c6e90b3aa53327b113f8/hpack-4.1.0.tar.gz", hash = "sha256:ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca", size = 51276 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/07/c6/80c95b1b2b94682a72cbdbfb85b81ae2daffa4291fbfa1b1464502ede10d/hpack-4.1.0-py3-none-any.whl", hash = "sha256:157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496", size = 34357 },
-]
-
-[[package]]
-name = "httpcore"
-version = "1.0.9"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "certifi", marker = "sys_platform == 'linux'" },
-    { name = "h11", marker = "sys_platform == 'linux'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784 },
-]
-
-[[package]]
-name = "httptools"
-version = "0.8.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/43/e5/d471fcb0e14523fe1c3f4ba58ca52480e7bd70ad7109a3846bc75892f7fb/httptools-0.8.0.tar.gz", hash = "sha256:6b2a32f18d97e16e90827d7a819ffa8dbd8cc245fc4e1fa9d1095b54ef4bd999", size = 271342 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/d4/13025f1a56e615dcb331e0bbe2d9a1143212b58c263385fc5d2e558f5bac/httptools-0.8.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:57278e6fa0424c42a8a3e454828ab4f0aff27b40cddf9679579b98c6dce6a376", size = 464676 },
-    { url = "https://files.pythonhosted.org/packages/b5/f9/5811c74f37a758c8a4aa3dc430375119d335947e883efc4664d8f3559a41/httptools-0.8.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:20b4aac66ff65f7db06a375808b78f42a94970aa22e826b3cb2b43eb09174124", size = 452174 },
-    { url = "https://files.pythonhosted.org/packages/e3/a6/febbb8b8db0f58b38e44ad6cb946e6a255ae49b55f2e8543408fb7501ccd/httptools-0.8.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b15fc622b0f869d19207c4089a501d9bcc63ca5e071ffdd2f03f922df882dcb2", size = 523851 },
-    { url = "https://files.pythonhosted.org/packages/ca/42/906adc91ae3a5fa9c59c0a2f21c139725bd7e5b41ae6acd485cd14123ebf/httptools-0.8.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a1afd7c9fbff0d9f5d489c4ce2768bd09c84a46ddefc7161e6aa82ae35c85745", size = 509567 },
-]
-
-[[package]]
-name = "httpx"
-version = "0.28.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio", marker = "sys_platform == 'linux'" },
-    { name = "certifi", marker = "sys_platform == 'linux'" },
-    { name = "httpcore", marker = "sys_platform == 'linux'" },
-    { name = "idna", marker = "sys_platform == 'linux'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517 },
 ]
 
 [[package]]
@@ -1023,11 +773,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a8/af/48ac8483240de756d2438c380746e7130d1c6f75802ef22f3c6d49982787/huggingface_hub-0.36.2-py3-none-any.whl", hash = "sha256:48f0c8eac16145dfce371e9d2d7772854a4f591bcb56c9cf548accf531d54270", size = 566395 },
 ]
 
-[package.optional-dependencies]
-hf-xet = [
-    { name = "hf-xet", marker = "sys_platform == 'linux'" },
-]
-
 [[package]]
 name = "hyperframe"
 version = "6.1.0"
@@ -1044,18 +789,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b9/28/99c51f664567218d824af024c0251650fb27e4ca066df188dab0769c5b91/idna-3.17.tar.gz", hash = "sha256:5eb0cb53bc467c12eadcf6de83163ad8527cec9416f44b9b61b19caedad2b87f", size = 196048 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/de/a7/f76514cc40ad6234098ecdebda08732d75964776c51a42845b7da10649e2/idna-3.17-py3-none-any.whl", hash = "sha256:466e48829084efe2548012b855df21540b96f2e20e51bd124c851536556a592c", size = 65316 },
-]
-
-[[package]]
-name = "importlib-metadata"
-version = "8.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "zipp", marker = "sys_platform == 'linux'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/20/ff/bd28f70283b9cca0cbf0c2a6082acbecd822d1962ae7b2a904861b9965f8/importlib_metadata-8.0.0.tar.gz", hash = "sha256:188bd24e4c346d3f0a933f275c2fec67050326a856b9a359881d7c2a697e8812", size = 52667 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/ef/38766b2edb096260d9b1b6ad35adaa0bce3b0567abb452b21eb074af88c4/importlib_metadata-8.0.0-py3-none-any.whl", hash = "sha256:15584cf2b1bf449d98ff8a6ff1abef57bf20f3ac6454f431736cd3e660921b2f", size = 24769 },
 ]
 
 [[package]]
@@ -1148,28 +881,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899 },
-]
-
-[[package]]
-name = "jiter"
-version = "0.15.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/66/b5/55f06bb281d92fb3cc86d14e1def2bd908bb77693183e7cb1f5a3c388b0c/jiter-0.15.0.tar.gz", hash = "sha256:4251acc80e2b7c9b7b8823456ea0fceeb0734dac2df7636d3c711b38476b5a76", size = 166640 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/2a/e71dea19822e2e404e83992a08c1d6b9b617bb944f28c9c2fbd85d02c91e/jiter-0.15.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:773b6eb282ce11ee19f05f6b2d4404fa308e5bbd353b0b80a0262caad6db2cd7", size = 366214 },
-    { url = "https://files.pythonhosted.org/packages/c4/59/97e1fa539d124a509a00ab7f669289d1c1d236ecabf12948a18f16c91082/jiter-0.15.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8d2c0c44d569ce0f2850f5c926f8caeb5f245fbc84475aeb36efccc2103e6dbd", size = 459527 },
-    { url = "https://files.pythonhosted.org/packages/d1/7a/4a68d331aef8cf2e2393c14a3aacb635c62aa86071b0229899fb5baaa907/jiter-0.15.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:032396229564bca02440396bd327710719f724f5e7b7e9f7a8eb3faa4a2c2281", size = 375451 },
-    { url = "https://files.pythonhosted.org/packages/7b/7e/1c445c2b6f0e30a274dc8082e0c3c7825411cce80d726bccd697c98cc8d3/jiter-0.15.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f3d37768fce7f88dd2a8c6091f2325dea27d30d30d5c6e7a1c0f0af77723b708", size = 349428 },
-    { url = "https://files.pythonhosted.org/packages/00/94/e20d38984fc17a636371bffd2ae0f698124fdc8e75ef969cd2da6ba7cea7/jiter-0.15.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:2c9cb907439d20bd0c7d7565ca01ee52234203208433749bae5b516907526928", size = 355405 },
-    { url = "https://files.pythonhosted.org/packages/e7/2c/5e07874e59e623a943a0acf1552a80d05b70f31b402287a8fc6d7ec634c7/jiter-0.15.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:8020c99ec13a7db2b6f96cbe82ef4721c88b426a4892f27478044af0284615ef", size = 551016 },
-    { url = "https://files.pythonhosted.org/packages/c3/b6/f5739011d009b3a30f6a53c5240979030ba29ae46a8c67e3a15759f7c37d/jiter-0.15.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5f30bae8bc1c2d613e28e5af3e8cceb09b742f1c8a8a5f839fb67afaffc03b61", size = 363555 },
-    { url = "https://files.pythonhosted.org/packages/e5/12/98a9d9f766665e8a3b6252454e17cb0c464606a28cf2fa09399b003345fa/jiter-0.15.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c60e71b6d10cfc284c9bf36bd885e8d44c46f688ce50aa91b5edd90181dea687", size = 452255 },
-    { url = "https://files.pythonhosted.org/packages/e8/d5/60f972840f79c5e7544fce567c56f1e4e50468f996baba3e78d823dd62a6/jiter-0.15.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0ab068bce62a45aa3e7367eceaffb5dde60b7eb853be8dece45132e3d0ff4879", size = 373559 },
-    { url = "https://files.pythonhosted.org/packages/ee/cf/d46ef1234ba335aabc2f013210db8e0821a22f5e644a2e9449df199ecc23/jiter-0.15.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fa248c9eb220197d363f688818dac2fd4b2f0cd7d843ca7105d652034823427d", size = 346055 },
-    { url = "https://files.pythonhosted.org/packages/f0/63/4d2749d8d54d230bad9b3a6b0d00cc28c6ff6b2fdffc26a8ccf76cc5a974/jiter-0.15.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:2a77aadd57cac1682e4401a72724d2796d89a4ba129b1a5812aa94ee480826eb", size = 351406 },
-    { url = "https://files.pythonhosted.org/packages/e8/76/a0c40ad064d3a20a4fde231e35d56e9a01ce82164278180e82d5daf85469/jiter-0.15.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:2fb6a5d26af81fc0f00f9360a891e05cf755e149bba391c4d563adc54812973d", size = 548646 },
-    { url = "https://files.pythonhosted.org/packages/34/56/55d76614af37fe3f22a3347d1e410d2a15da581997cb2da499a625000bb5/jiter-0.15.0-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b15d3ec9b0449c40e85319bdb4caa8b77ab526e74f5532ed94bec15e2f66822c", size = 345606 },
-    { url = "https://files.pythonhosted.org/packages/c8/8d/302cb2057b7513327b4d575cff6b1d066ee6431a5357fc3f8867cd684406/jiter-0.15.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:54d5d6090cdc1b7c9e780dfb04949a990adb1e301a2fc0bbcee7de4638d33f9a", size = 344469 },
 ]
 
 [[package]]
@@ -1273,28 +984,29 @@ wheels = [
 ]
 
 [[package]]
-name = "llvmlite"
-version = "0.44.0"
+name = "lxml"
+version = "6.1.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/89/6a/95a3d3610d5c75293d5dbbb2a76480d5d4eeba641557b69fe90af6c5b84e/llvmlite-0.44.0.tar.gz", hash = "sha256:07667d66a5d150abed9157ab6c0b9393c9356f229784a4385c02f99e94fc94d4", size = 171880 }
+sdist = { url = "https://files.pythonhosted.org/packages/05/3b/aab6728cae887456f409b4d75e8a01856e4f04bd510de38052a47768b680/lxml-6.1.1.tar.gz", hash = "sha256:ba96ae44888e0185281e937633a743ea90d5a196c6000f82565ebb0580012d40", size = 4197430 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/99/fe/d030f1849ebb1f394bb3f7adad5e729b634fb100515594aca25c354ffc62/llvmlite-0.44.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c5d22c3bfc842668168a786af4205ec8e3ad29fb1bc03fd11fd48460d0df64c1", size = 42361858 },
-    { url = "https://files.pythonhosted.org/packages/cb/da/8341fd3056419441286c8e26bf436923021005ece0bff5f41906476ae514/llvmlite-0.44.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c0143a5ef336da14deaa8ec26c5449ad5b6a2b564df82fcef4be040b9cacfea9", size = 42361901 },
-]
-
-[[package]]
-name = "lm-format-enforcer"
-version = "0.10.12"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "interegular", marker = "sys_platform == 'linux'" },
-    { name = "packaging", marker = "sys_platform == 'linux'" },
-    { name = "pydantic", marker = "sys_platform == 'linux'" },
-    { name = "pyyaml", marker = "sys_platform == 'linux'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/eb/e0/bdbfad8f5d319de5d05cc2b70d579b49eb8ce3a09989cd0999b8c138c068/lm_format_enforcer-0.10.12.tar.gz", hash = "sha256:130bd7ce8a6b224f25b6314ba9ae78ee4b48594db1767c74391c9182e2902a6c", size = 39481 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/57/1c/7bb80fe2dff9a9c38b180571ca867f518eb9110f79d4b670ea124e153680/lm_format_enforcer-0.10.12-py3-none-any.whl", hash = "sha256:267c2b421c77f7cd51ac2e0e3af8db278a373704d834b49ff55f18a2c05e9800", size = 44327 },
+    { url = "https://files.pythonhosted.org/packages/4c/77/1bc7eeb0de4577d783fb625aa092cc9357883bba35845a3666bf1259f3dc/lxml-6.1.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:db1d75f6617a49c1c01bc7023713e0ff59ab32c9579ae62a7674c0e34f3b0b0a", size = 5067921 },
+    { url = "https://files.pythonhosted.org/packages/66/8d/d1b3271af0c0f1e27e8472a849e4d2c65bc7766884b9ad2da9e76e145c88/lxml-6.1.1-cp311-cp311-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:18b73c339ae29b90fd2d06e58ebd555a751bde9cd6bbd36cc0281b9a2c94e9d8", size = 5202776 },
+    { url = "https://files.pythonhosted.org/packages/5d/c0/ef73af53767e958fd87d437c170f272e2f6e6c0f854939f133a895f1e711/lxml-6.1.1-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:6b1761fbf9ec984e2e9d9c589ef5f5fd684b7c19f92aadd567a26c5224958db6", size = 4659237 },
+    { url = "https://files.pythonhosted.org/packages/a0/5e/e1158e40397585e91cb0472374a1f63d0926a1ddeaa92f13d1a1ffe306d5/lxml-6.1.1-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d680fbcb768404c601ecb43519ecd8461f6954cb11c06a78962f666832ccfca8", size = 5265904 },
+    { url = "https://files.pythonhosted.org/packages/ca/18/d877bd1ae2e5ffdfd4836565aba350db31feb2f2656d6ce70316ed66a05e/lxml-6.1.1-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:e9308ff8241c532df3f3e570f9a5aeed6c853f888512ba4b75638d7c11c95ef6", size = 4712721 },
+    { url = "https://files.pythonhosted.org/packages/44/4d/1f44fd1d770b10dacbf6b5c6e520f4d6e0708744930f719dc04e67cab981/lxml-6.1.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:5f6994074ebae6ffb04447268e37dc16edc304f9859cf91acb86e0af6c1b395c", size = 5252549 },
+    { url = "https://files.pythonhosted.org/packages/64/5d/1d66b84f850089254c230ef6ea6b267a5a54e2e179a5d960036a05d501d7/lxml-6.1.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:80c2dfadb855da477cf73373ad29a333535dedb9b12bad02c9814c8e2b43bf08", size = 5226877 },
+    { url = "https://files.pythonhosted.org/packages/eb/99/0013e8d9b5960f4f041cf0b73e2f80c23eb5205b1f7bfb20203243651359/lxml-6.1.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:54a7f95e4de5fb94e2f9f4b9055c6ba33bf3d628fd77a1d647c5923caa2cdcdc", size = 5093723 },
+    { url = "https://files.pythonhosted.org/packages/42/2f/cc9bf06afe70f9c9093ae60855d9759da9db601ec4080f7473319666ffd7/lxml-6.1.1-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:70ef8a7e102a1508f8121aae5b0867abd663f72c14f0a9c937e6554cb4587b7b", size = 5631036 },
+    { url = "https://files.pythonhosted.org/packages/08/f6/af32e23e563971ffb0fb86be52bc5be5c2c118858ffc119bf6a9039b173d/lxml-6.1.1-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ebe6af670449830d6d9b752c256a983291c766a1365ba5d5460048f9e33a7818", size = 5240367 },
+    { url = "https://files.pythonhosted.org/packages/63/75/5d92da93729b7bad783689e6496049fa40927b45bec7bf183c981de3ca70/lxml-6.1.1-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:1db753c9115ec7100d073b744d17e25e88a8f90f5c39b2f5dd878149af59671f", size = 4694874 },
+    { url = "https://files.pythonhosted.org/packages/c5/b5/3aad415a9a25b822e783f15deeb4dffccf5113030f1afa2222dd929313d9/lxml-6.1.1-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c4f469aebd783bb741c2ecb2a681008fd26bfe5c16a9a72ed5467f834e810df2", size = 5244492 },
+    { url = "https://files.pythonhosted.org/packages/77/74/1f601b63c7a69fcdf10fa9b148c81da8442204194f6c55509cc485c786b9/lxml-6.1.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:b8d812c6011c08b8111a15e54dd990b8923692d80adf35488bee34026c35accf", size = 4777023 },
+    { url = "https://files.pythonhosted.org/packages/a2/b9/7a78f51aec95b1bf780d78e12705a9f6533284f8693dc5c0e6724fa53d3f/lxml-6.1.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:fe0306bd29505a9177aac19f1877174b0e7422c222a59f70b2cd41633448c3dc", size = 5645773 },
+    { url = "https://files.pythonhosted.org/packages/a5/6e/98a7b7ad54e4e74fa1f20fff776913980619d0ebe5558232d7da6580bdd8/lxml-6.1.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:5ba186ad207446c65d3bb3d3e0412b032b1d9f595e59861e2354798c5703d955", size = 5233088 },
+    { url = "https://files.pythonhosted.org/packages/65/d1/bc0ed2427bf609f2ee10da303a6a226f9c8bce94f945dc29a32ce55de6e4/lxml-6.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:aa366a1e55b8ebfe8ca8ddc3cfe75c8ebade181aeb0f661d0cb05986b647f72a", size = 5260995 },
+    { url = "https://files.pythonhosted.org/packages/6d/39/0dc5949f759ed7d951e0bb8c2f2d9d7aca1908d22352fa84a8afd2ea54af/lxml-6.1.1-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c07da4cebf6889f03ebac8d238f62318e29f495de0aa18a51ea14e61ae907e2e", size = 4318163 },
+    { url = "https://files.pythonhosted.org/packages/68/1b/7553ab136894374ffae8851ec06f98f511cd8e66246e41b6be059d0a7289/lxml-6.1.1-pp311-pypy311_pp73-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f8844cd288697c6425c9beba919302241e3278871dc6519515e72b04e987abcf", size = 4401664 },
 ]
 
 [[package]]
@@ -1385,30 +1097,6 @@ wheels = [
 ]
 
 [[package]]
-name = "mistral-common"
-version = "1.11.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "jsonschema", marker = "sys_platform == 'linux'" },
-    { name = "numpy", marker = "sys_platform == 'linux'" },
-    { name = "pillow", marker = "sys_platform == 'linux'" },
-    { name = "pydantic", marker = "sys_platform == 'linux'" },
-    { name = "pydantic-extra-types", extra = ["pycountry"], marker = "sys_platform == 'linux'" },
-    { name = "requests", marker = "sys_platform == 'linux'" },
-    { name = "tiktoken", marker = "sys_platform == 'linux'" },
-    { name = "typing-extensions", marker = "sys_platform == 'linux'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c2/eb/12167a1bea9714582e5b4f539f9c019323363e314a499c72855ff0e5ad43/mistral_common-1.11.2.tar.gz", hash = "sha256:79f68fc2d1190f28637f40e053f919c8c2697e00b2aa679ddee562a95183f4ad", size = 6357845 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/47/f0/6a5d604b972e442b9d36c117d01788feddad099e4965699e3516ee6fefc3/mistral_common-1.11.2-py3-none-any.whl", hash = "sha256:ebb42062cd705a0aa2bc69b4cde2b83d446ae58150b7e29322c90cb08fcfca6c", size = 6531968 },
-]
-
-[package.optional-dependencies]
-opencv = [
-    { name = "opencv-python-headless", marker = "sys_platform == 'linux'" },
-]
-
-[[package]]
 name = "modal"
 version = "1.4.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1433,10 +1121,21 @@ wheels = [
 ]
 
 [[package]]
-name = "mpi4py"
-version = "4.0.3"
+name = "modelscope"
+version = "1.37.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0d/b6/833caa35145efa52c698c50bc76dd9cd2d30527193a9b54004a76c9d99b4/mpi4py-4.0.3.tar.gz", hash = "sha256:de2710d73e25e115865a3ab63d34a54b2d8608b724f761c567b6ad58dd475609", size = 466338 }
+dependencies = [
+    { name = "filelock", marker = "sys_platform == 'linux'" },
+    { name = "packaging", marker = "sys_platform == 'linux'" },
+    { name = "requests", marker = "sys_platform == 'linux'" },
+    { name = "setuptools", marker = "sys_platform == 'linux'" },
+    { name = "tqdm", marker = "sys_platform == 'linux'" },
+    { name = "urllib3", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fa/9e/9fd75db9797b9543ce78a646538a3c5537cb6adb015d128b4cbc2b4169e2/modelscope-1.37.1.tar.gz", hash = "sha256:7d9124970b4e53639bebe89f60473dee7d5a80589bf35bfbef4c839933cdaf93", size = 4594233 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/f5/286dd2d21802e4954a28e73913af7bc79e882f23fcd98db2b5810fc590cf/modelscope-1.37.1-py3-none-any.whl", hash = "sha256:7f7af2dd37339188cbd3c18a858b1297b8a75222b9a0fbf176c7df8189cac39a", size = 6089945 },
+]
 
 [[package]]
 name = "mpmath"
@@ -1445,18 +1144,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198 },
-]
-
-[[package]]
-name = "msgpack"
-version = "1.1.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4d/f2/bfb55a6236ed8725a96b0aa3acbd0ec17588e6a2c3b62a93eb513ed8783f/msgpack-1.1.2.tar.gz", hash = "sha256:3b60763c1373dd60f398488069bcdc703cd08a711477b5d480eecc9f9626f47e", size = 173581 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/e0/6cc2e852837cd6086fe7d8406af4294e66827a60a4cf60b86575a4a65ca8/msgpack-1.1.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:454e29e186285d2ebe65be34629fa0e8605202c60fbc7c4c650ccd41870896ef", size = 426183 },
-    { url = "https://files.pythonhosted.org/packages/b7/cd/9098fcb6adb32187a70b7ecaabf6339da50553351558f37600e53a4a2a23/msgpack-1.1.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:bafca952dc13907bdfdedfc6a5f579bf4f292bdd506fadb38389afa3ac5b208e", size = 422341 },
-    { url = "https://files.pythonhosted.org/packages/65/92/a5100f7185a800a5d29f8d14041f61475b9de465ffcc0f3b9fba606e4505/msgpack-1.1.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:372839311ccf6bdaf39b00b61288e0557916c3729529b301c52c2d88842add42", size = 427556 },
-    { url = "https://files.pythonhosted.org/packages/ff/41/8543ed2b8604f7c0d89ce066f42007faac1eaa7d79a81555f206a5cdb889/msgpack-1.1.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:be52a8fc79e45b0364210eef5234a7cf8d330836d0a64dfbb878efa903d84620", size = 415013 },
 ]
 
 [[package]]
@@ -1566,20 +1253,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/3c/fb/95752eb635bb8ad27d101d71bef15bc63049de23f299e312878fc21cb2da/ninja-1.13.0-py3-none-musllinux_1_2_riscv64.whl", hash = "sha256:d741a5e6754e0bda767e3274a0f0deeef4807f1fec6c0d7921a0244018926ae5", size = 585106 },
     { url = "https://files.pythonhosted.org/packages/c1/31/aa56a1a286703800c0cbe39fb4e82811c277772dc8cd084f442dd8e2938a/ninja-1.13.0-py3-none-musllinux_1_2_s390x.whl", hash = "sha256:e8bad11f8a00b64137e9b315b137d8bb6cbf3086fbdc43bf1f90fd33324d2e96", size = 707138 },
     { url = "https://files.pythonhosted.org/packages/34/6f/5f5a54a1041af945130abdb2b8529cbef0cdcbbf9bcf3f4195378319d29a/ninja-1.13.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:b4f2a072db3c0f944c32793e91532d8948d20d9ab83da9c0c7c15b5768072200", size = 581758 },
-]
-
-[[package]]
-name = "numba"
-version = "0.61.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "llvmlite", marker = "sys_platform == 'linux'" },
-    { name = "numpy", marker = "sys_platform == 'linux'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/1c/a0/e21f57604304aa03ebb8e098429222722ad99176a4f979d34af1d1ee80da/numba-0.61.2.tar.gz", hash = "sha256:8750ee147940a6637b80ecf7f95062185ad8726c8c28a2295b8ec1160a196f7d", size = 2820615 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/97/c8/8740616c8436c86c1b9a62e72cb891177d2c34c2d24ddcde4c390371bf4c/numba-0.61.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3945615cd73c2c7eba2a85ccc9c1730c21cd3958bfcf5a44302abae0fb07bb60", size = 3829227 },
-    { url = "https://files.pythonhosted.org/packages/9a/2d/e518df036feab381c23a624dac47f8445ac55686ec7f11083655eb707da3/numba-0.61.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5b1bb509d01f23d70325d3a5a0e237cbc9544dd50e50588bc581ba860c213546", size = 3885928 },
 ]
 
 [[package]]
@@ -1705,6 +1378,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nvidia-ml-py"
+version = "13.610.43"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/b5/a8fbc356f768fa5c9cfd646668fd7d34bf55bdd1c6e20754642a64d930d4/nvidia_ml_py-13.610.43.tar.gz", hash = "sha256:65437eb73d68d0c62c931ca4d45038472faff03bd0b8729abba4b899f70d60f2", size = 52109 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/45/caa600acfab94560807a20a64b5830d2cd3c3202b7f1328644d70b7d6bd8/nvidia_ml_py-13.610.43-py3-none-any.whl", hash = "sha256:f13c72698edef492f985cc225f14faafe68ae065a2e407f45bdf6f4b9b43fde8", size = 53163 },
+]
+
+[[package]]
 name = "nvidia-nccl-cu12"
 version = "2.21.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1729,156 +1411,23 @@ wheels = [
 ]
 
 [[package]]
-name = "openai"
-version = "2.40.0"
+name = "orjson"
+version = "3.11.9"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio", marker = "sys_platform == 'linux'" },
-    { name = "distro", marker = "sys_platform == 'linux'" },
-    { name = "httpx", marker = "sys_platform == 'linux'" },
-    { name = "jiter", marker = "sys_platform == 'linux'" },
-    { name = "pydantic", marker = "sys_platform == 'linux'" },
-    { name = "sniffio", marker = "sys_platform == 'linux'" },
-    { name = "tqdm", marker = "sys_platform == 'linux'" },
-    { name = "typing-extensions", marker = "sys_platform == 'linux'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f9/9f/136562ec6c3b1a50fe06eb0bb34ed21f0d7426ec0140e5cc43ac785b69a5/openai-2.40.0.tar.gz", hash = "sha256:9a756f91f274a24ad6026cbcb2042fd356c8d4a10e8f347b08d34465e585f7a2", size = 781177 }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/0c/964746fcafbd16f8ff53219ad9f6b412b34f345c75f384ad434ceaadb538/orjson-3.11.9.tar.gz", hash = "sha256:4fef17e1f8722c11587a6ef18e35902450221da0028e65dbaaa543619e68e48f", size = 5599163 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/46/180e14be801a75bc13f234cb1b594b232adeb9c84e60a9ab1832e8333591/openai-2.40.0-py3-none-any.whl", hash = "sha256:2b205637ff214477f9ce9ab035e9f494db0e3fa8f1e599008953735fbf6ff1ff", size = 1350935 },
-]
-
-[[package]]
-name = "opencv-python-headless"
-version = "4.13.0.92"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy", marker = "sys_platform == 'linux'" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/92/ce/bd17ff5772938267fd49716e94ca24f616ff4cb1ff4c6be13085108037be/opencv_python_headless-4.13.0.92-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0525a3d2c0b46c611e2130b5fdebc94cf404845d8fa64d2f3a3b679572a5bd22", size = 56016764 },
-    { url = "https://files.pythonhosted.org/packages/4b/33/b5db29a6c00eb8f50708110d8d453747ca125c8b805bc437b289dbdcc057/opencv_python_headless-4.13.0.92-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0bd48544f77c68b2941392fcdf9bcd2b9cdf00e98cb8c29b2455d194763cf99e", size = 60391106 },
-]
-
-[[package]]
-name = "opentelemetry-api"
-version = "1.26.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "deprecated", marker = "sys_platform == 'linux'" },
-    { name = "importlib-metadata", marker = "sys_platform == 'linux'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/48/d4/e9a0ddef6eed086c96e8265d864a46da099611b7be153b0cfb63fd47e1b4/opentelemetry_api-1.26.0.tar.gz", hash = "sha256:2bd639e4bed5b18486fef0b5a520aaffde5a18fc225e808a1ac4df363f43a1ce", size = 60904 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e3/a7/6322d1d7a1fb926e8b99208c27730f21217da2f1e0e11dab48a78a0427a4/opentelemetry_api-1.26.0-py3-none-any.whl", hash = "sha256:7d7ea33adf2ceda2dd680b18b1677e4152000b37ca76e679da71ff103b943064", size = 61533 },
-]
-
-[[package]]
-name = "opentelemetry-exporter-otlp"
-version = "1.26.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "opentelemetry-exporter-otlp-proto-grpc", marker = "sys_platform == 'linux'" },
-    { name = "opentelemetry-exporter-otlp-proto-http", marker = "sys_platform == 'linux'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/be/99/80edf6286f9040fadf065f9a11869fda34449a61e62a5372cb84d5a6f53b/opentelemetry_exporter_otlp-1.26.0.tar.gz", hash = "sha256:cf0e093f080011951d9f97431a83869761e4d4ebe83a4195ee92d7806223299c", size = 6168 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/71/b9221af6af61213c522401b5f46a5eaa41d8dd7daeb0740dc5604f5c3980/opentelemetry_exporter_otlp-1.26.0-py3-none-any.whl", hash = "sha256:f839989f54bda85ee33c5dae033c44dcec9ccbb0dafc6a43d585df44da1d2036", size = 7001 },
-]
-
-[[package]]
-name = "opentelemetry-exporter-otlp-proto-common"
-version = "1.26.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "opentelemetry-proto", marker = "sys_platform == 'linux'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/84/cd/ed9eaa1d80facb6609d02af6c393b02ce3797a15742361be4859db6fdc17/opentelemetry_exporter_otlp_proto_common-1.26.0.tar.gz", hash = "sha256:bdbe50e2e22a1c71acaa0c8ba6efaadd58882e5a5978737a44a4c4b10d304c92", size = 17815 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/25/2f/0f7e0a73fd901c9abc6ea680d7f19a803dac830c450f21e1123d3a3ec488/opentelemetry_exporter_otlp_proto_common-1.26.0-py3-none-any.whl", hash = "sha256:ee4d8f8891a1b9c372abf8d109409e5b81947cf66423fd998e56880057afbc71", size = 17837 },
-]
-
-[[package]]
-name = "opentelemetry-exporter-otlp-proto-grpc"
-version = "1.26.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "deprecated", marker = "sys_platform == 'linux'" },
-    { name = "googleapis-common-protos", marker = "sys_platform == 'linux'" },
-    { name = "grpcio", marker = "sys_platform == 'linux'" },
-    { name = "opentelemetry-api", marker = "sys_platform == 'linux'" },
-    { name = "opentelemetry-exporter-otlp-proto-common", marker = "sys_platform == 'linux'" },
-    { name = "opentelemetry-proto", marker = "sys_platform == 'linux'" },
-    { name = "opentelemetry-sdk", marker = "sys_platform == 'linux'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a0/23/cac89aca97ecb8f7498a875dc2ac89224b4f3345bcb8ffff643b59886196/opentelemetry_exporter_otlp_proto_grpc-1.26.0.tar.gz", hash = "sha256:a65b67a9a6b06ba1ec406114568e21afe88c1cdb29c464f2507d529eb906d8ae", size = 25239 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/0c/e4473692fec8076008c7926dfcef7223fc6d2785f04ad9d8402347a4eba9/opentelemetry_exporter_otlp_proto_grpc-1.26.0-py3-none-any.whl", hash = "sha256:e2be5eff72ebcb010675b818e8d7c2e7d61ec451755b8de67a140bc49b9b0280", size = 18228 },
-]
-
-[[package]]
-name = "opentelemetry-exporter-otlp-proto-http"
-version = "1.26.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "deprecated", marker = "sys_platform == 'linux'" },
-    { name = "googleapis-common-protos", marker = "sys_platform == 'linux'" },
-    { name = "opentelemetry-api", marker = "sys_platform == 'linux'" },
-    { name = "opentelemetry-exporter-otlp-proto-common", marker = "sys_platform == 'linux'" },
-    { name = "opentelemetry-proto", marker = "sys_platform == 'linux'" },
-    { name = "opentelemetry-sdk", marker = "sys_platform == 'linux'" },
-    { name = "requests", marker = "sys_platform == 'linux'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/42/d2/4e6e2066b87626966f99f8fc7fcb9414e7548779d751def7db54c9d25b1c/opentelemetry_exporter_otlp_proto_http-1.26.0.tar.gz", hash = "sha256:5801ebbcf7b527377883e6cbbdda35ee712dc55114fff1e93dfee210be56c908", size = 14451 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cf/d3/0b7217b61903249035d219fbe93a8558287f86aead340c7b2dc1226b8ad4/opentelemetry_exporter_otlp_proto_http-1.26.0-py3-none-any.whl", hash = "sha256:ee72a87c48ec977421b02f16c52ea8d884122470e0be573905237b540f4ee562", size = 16795 },
-]
-
-[[package]]
-name = "opentelemetry-proto"
-version = "1.26.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "protobuf", marker = "sys_platform == 'linux'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a9/06/9505ef04e527fa711ebffb47f3f56cac6015405953ff688fc349d170fb9c/opentelemetry_proto-1.26.0.tar.gz", hash = "sha256:c5c18796c0cab3751fc3b98dee53855835e90c0422924b484432ac852d93dc1e", size = 34749 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/15/f4/66a3892eea913cded9bac0fdd3fb1a412fa2da8eb50014ec87a52648444a/opentelemetry_proto-1.26.0-py3-none-any.whl", hash = "sha256:6c4d7b4d4d9c88543bcf8c28ae3f8f0448a753dc291c18c5390444c90b76a725", size = 52466 },
-]
-
-[[package]]
-name = "opentelemetry-sdk"
-version = "1.26.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "opentelemetry-api", marker = "sys_platform == 'linux'" },
-    { name = "opentelemetry-semantic-conventions", marker = "sys_platform == 'linux'" },
-    { name = "typing-extensions", marker = "sys_platform == 'linux'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/d3/85/8ca0d5ebfe708287b091dffcd15553b74bbfe4532f8dd42662b78b2e0cab/opentelemetry_sdk-1.26.0.tar.gz", hash = "sha256:c90d2868f8805619535c05562d699e2f4fb1f00dbd55a86dcefca4da6fa02f85", size = 143139 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/92/f1/a9b550d0f9c049653dd2eab45cecf8fe4baa9795ed143d87834056ffabaf/opentelemetry_sdk-1.26.0-py3-none-any.whl", hash = "sha256:feb5056a84a88670c041ea0ded9921fca559efec03905dddeb3885525e0af897", size = 109475 },
-]
-
-[[package]]
-name = "opentelemetry-semantic-conventions"
-version = "0.47b0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "deprecated", marker = "sys_platform == 'linux'" },
-    { name = "opentelemetry-api", marker = "sys_platform == 'linux'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/93/85/edef14d10ad00ddd9fffb20e4d3d938f4c5c1247e11a175066fe2b4a72f8/opentelemetry_semantic_conventions-0.47b0.tar.gz", hash = "sha256:a8d57999bbe3495ffd4d510de26a97dadc1dace53e0275001b2c1b2f67992a7e", size = 83994 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/c2/ca5cef8e4cd8eec5a95deed95ec3f6005e499fd9d17ca08731ced03a6921/opentelemetry_semantic_conventions-0.47b0-py3-none-any.whl", hash = "sha256:4ff9d595b85a59c1c1413f02bba320ce7ea6bf9e2ead2b0913c4395c7bbc1063", size = 138027 },
-]
-
-[[package]]
-name = "opentelemetry-semantic-conventions-ai"
-version = "0.4.13"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ba/e6/40b59eda51ac47009fb47afcdf37c6938594a0bd7f3b9fadcbc6058248e3/opentelemetry_semantic_conventions_ai-0.4.13.tar.gz", hash = "sha256:94efa9fb4ffac18c45f54a3a338ffeb7eedb7e1bb4d147786e77202e159f0036", size = 5368 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/35/b5/cf25da2218910f0d6cdf7f876a06bed118c4969eacaf60a887cbaef44f44/opentelemetry_semantic_conventions_ai-0.4.13-py3-none-any.whl", hash = "sha256:883a30a6bb5deaec0d646912b5f9f6dcbb9f6f72557b73d0f2560bf25d13e2d5", size = 6080 },
+    { url = "https://files.pythonhosted.org/packages/ea/76/f11311285324a40aab1e3031385c50b635a7cd0734fdaf60c7e89a696f60/orjson-3.11.9-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a6082706765a95a6680d812e1daf1c0cfe8adec7831b3ff3b625693f3b461b1c", size = 127988 },
+    { url = "https://files.pythonhosted.org/packages/05/94/b0d27090ea8a2095db3c2bd1b1c96f96f19bbb494d7fef33130e846e613d/orjson-3.11.9-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:03db380e3780fa0015ed776a90f20e8e20bb11dde13b216ce19e5718e3dfba62", size = 145937 },
+    { url = "https://files.pythonhosted.org/packages/09/eb/75d50c29c05b8054013e221e598820a365c8e64065312e75e202ed880709/orjson-3.11.9-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:33d7d766701847dc6729846362dc27895d2f2d2251264f9d10e7cb9878194877", size = 132758 },
+    { url = "https://files.pythonhosted.org/packages/49/bd/360686f39348aa88827cb6fbf7dc606fd41c831a35235e1abf1db8e3a9e6/orjson-3.11.9-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:147302878da387104b66bb4a8b0227d1d487e976ce41a8501916161072ed87b1", size = 133971 },
+    { url = "https://files.pythonhosted.org/packages/5f/f1/ff2f19ed0225f9680fafa42febca3570dd59444ebf190980738d376214c2/orjson-3.11.9-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:c5d001196b89fa9cf0a4ab79766cd835b991a166e4b621ba95089edc50c429ff", size = 415167 },
+    { url = "https://files.pythonhosted.org/packages/b6/8a/4081492586d75b073d60c5271a8d0f05a0955cabf1e34c8473f6fcd84235/orjson-3.11.9-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:63e0efbc991250c0b3143488fa57d95affcabbfc63c99c48d625dd37779aafe2", size = 136959 },
+    { url = "https://files.pythonhosted.org/packages/d7/cf/b33b5f3e695ae7d63feef9d915c37cc3b8f465493dcd4f8e0b4c697a2366/orjson-3.11.9-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:011382e2a60fda9d46f1cdee31068cfc52ffe952b587d683ec0463002802a0f4", size = 127864 },
+    { url = "https://files.pythonhosted.org/packages/e8/f8/0b1bd3e8f2efcdd376af5c8cfd79eaf13f018080c0089c80ebd724e3c7fb/orjson-3.11.9-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d8ea516b3726d190e1b4297e6f4e7a8650347ae053868a18163b4dd3641d1fff", size = 145994 },
+    { url = "https://files.pythonhosted.org/packages/f3/59/dab79f61044c529d2c81aecdc589b1f833a1c8dec11ba3b1c2498a02ca7e/orjson-3.11.9-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:380cdce7ba24989af81d0a7013d0aaec5d0e2a21734c0e2681b1bc4f141957fe", size = 132744 },
+    { url = "https://files.pythonhosted.org/packages/0e/a4/82b7a2fe5d8a67a59ed831b24d59a3d46ea7d207b66e1602d376541d94a6/orjson-3.11.9-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:be4fa4f0af7fa18951f7ab3fc2148e223af211bf03f59e1c6034ec3f97f21d61", size = 134014 },
+    { url = "https://files.pythonhosted.org/packages/7f/7c/49d5d82a3d3097f641f094f552131f1e2723b0b8cb0fa2874ab65ecfffa6/orjson-3.11.9-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:4d7fde5501b944f83b3e665e1b31343ff6e154b15560a16b7130ea1e594a4206", size = 415127 },
+    { url = "https://files.pythonhosted.org/packages/df/e5/4d2d8af06f788329b4f78f8cc3679bb395392fcaa1e4d8d3c33e85308fa4/orjson-3.11.9-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:71e63adb0e1f1ed5d9e168f50a91ceb93ae6420731d222dc7da5c69409aa47aa", size = 136943 },
 ]
 
 [[package]]
@@ -2026,19 +1575,6 @@ wheels = [
 ]
 
 [[package]]
-name = "prometheus-fastapi-instrumentator"
-version = "8.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "prometheus-client", marker = "sys_platform == 'linux'" },
-    { name = "starlette", marker = "sys_platform == 'linux'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/98/7a/fe49b7060e585e2cfa28cc1d13ebfe9c2904dcd80cf11071d5de0f622ff2/prometheus_fastapi_instrumentator-8.0.0.tar.gz", hash = "sha256:c31ed192db077e75467b28b2fe5055362517f53369b798cb8dac9ff85f3f1c38", size = 20357 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/73/ad/b14ed2fe73bb1d37bcc947e75afae018f795526415d5b849aeb99c403cd1/prometheus_fastapi_instrumentator-8.0.0-py3-none-any.whl", hash = "sha256:e3c967c402124dfe81cf5aad35208d9f96db5452c6cb752350d9358ca0a96198", size = 19411 },
-]
-
-[[package]]
 name = "prompt-toolkit"
 version = "3.0.52"
 source = { registry = "https://pypi.org/simple" }
@@ -2142,15 +1678,6 @@ wheels = [
 ]
 
 [[package]]
-name = "py-cpuinfo"
-version = "9.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/37/a8/d832f7293ebb21690860d2e01d8115e5ff6f2ae8bbdc953f0eb0fa4bd2c7/py-cpuinfo-9.0.0.tar.gz", hash = "sha256:3cdbbf3fac90dc6f118bfd64384f309edeadd902d7c8fb17f02ffa1fc3f49690", size = 104716 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/a9/023730ba63db1e494a271cb018dcd361bd2c917ba7004c3e49d5daf795a2/py_cpuinfo-9.0.0-py3-none-any.whl", hash = "sha256:859625bc251f64e21f077d099d4162689c762b5d6a4c3c97553d56241c9674d5", size = 22335 },
-]
-
-[[package]]
 name = "pyarrow"
 version = "24.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2191,6 +1718,16 @@ wheels = [
 ]
 
 [[package]]
+name = "pycryptodomex"
+version = "3.23.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/85/e24bf90972a30b0fcd16c73009add1d7d7cd9140c2498a68252028899e41/pycryptodomex-3.23.0.tar.gz", hash = "sha256:71909758f010c82bc99b0abf4ea12012c98962fbf0583c2164f8b84533c2e4da", size = 4922157 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/a9/8862616a85cf450d2822dbd4fff1fcaba90877907a6ff5bc2672cafe42f8/pycryptodomex-3.23.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f489c4765093fb60e2edafdf223397bc716491b2b69fe74367b70d6999257a5c", size = 2272578 },
+    { url = "https://files.pythonhosted.org/packages/a5/e9/e869bcee87beb89040263c416a8a50204f7f7a83ac11897646c9e71e0daf/pycryptodomex-3.23.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:55ccbe27f049743a4caf4f4221b166560d3438d0b1e5ab929e07ae1702a4d6fd", size = 2271038 },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.13.4"
 source = { registry = "https://pypi.org/simple" }
@@ -2203,11 +1740,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262 },
-]
-
-[package.optional-dependencies]
-email = [
-    { name = "email-validator", marker = "sys_platform == 'linux'" },
 ]
 
 [[package]]
@@ -2268,44 +1800,24 @@ wheels = [
 ]
 
 [[package]]
-name = "pydantic-extra-types"
-version = "2.11.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pydantic", marker = "sys_platform == 'linux'" },
-    { name = "typing-extensions", marker = "sys_platform == 'linux'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/66/71/dba38ee2651f84f7842206adbd2233d8bbdb59fb85e9fa14232486a8c471/pydantic_extra_types-2.11.1.tar.gz", hash = "sha256:46792d2307383859e923d8fcefa82108b1a141f8a9c0198982b3832ab5ef1049", size = 172002 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/c1/3226e6d7f5a4f736f38ac11a6fbb262d701889802595cdb0f53a885ac2e0/pydantic_extra_types-2.11.1-py3-none-any.whl", hash = "sha256:1722ea2bddae5628ace25f2aa685b69978ef533123e5638cfbddb999e0100ec1", size = 79526 },
-]
-
-[package.optional-dependencies]
-pycountry = [
-    { name = "pycountry", marker = "sys_platform == 'linux'" },
-]
-
-[[package]]
-name = "pydantic-settings"
-version = "2.14.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pydantic", marker = "sys_platform == 'linux'" },
-    { name = "python-dotenv", marker = "sys_platform == 'linux'" },
-    { name = "typing-inspection", marker = "sys_platform == 'linux'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/07/60/1d1e59c9c90d54591469ada7d268251f71c24bdb765f1a8a832cee8c6653/pydantic_settings-2.14.1.tar.gz", hash = "sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa", size = 235551 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/8d/f1af3832f5e6eb13ba94ee809e72b8ecb5eef226d27ee0bef7d963d943c7/pydantic_settings-2.14.1-py3-none-any.whl", hash = "sha256:6e3c7edfd8277687cdc598f56e5cff0e9bfff0910a3749deaa8d4401c3a2b9de", size = 60964 },
-]
-
-[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151 },
+]
+
+[[package]]
+name = "pynvml"
+version = "13.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-ml-py", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/57/da7dc63a79f59e082e26a66ac02d87d69ea316b35b35b7a00d82f3ce3d2f/pynvml-13.0.1.tar.gz", hash = "sha256:1245991d9db786b4d2f277ce66869bd58f38ac654e38c9397d18f243c8f6e48f", size = 35226 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/4a/cac76c174bb439a0c46c9a4413fcbea5c6cabfb01879f7bbdb9fdfaed76c/pynvml-13.0.1-py3-none-any.whl", hash = "sha256:e2b20e0a501eeec951e2455b7ab444759cf048e0e13a57b08049fa2775266aa8", size = 28810 },
 ]
 
 [[package]]
@@ -2327,15 +1839,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/88/2c/7bb1416c5620485aa793f2de31d3df393d3686aa8a8506d11e10e13c5baf/python_dotenv-1.1.0.tar.gz", hash = "sha256:41f90bc6f5f177fb41f53e87666db362025010eb28f60a01c9143bfa33a2b2d5", size = 39920 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/18/98a99ad95133c6a6e2005fe89faedf294a748bd5dc803008059409ac9b1e/python_dotenv-1.1.0-py3-none-any.whl", hash = "sha256:d7c01d9e2293916c18baf562d95698754b0dbbb5e74d457c45d4f6561fb9d55d", size = 20256 },
-]
-
-[[package]]
-name = "python-json-logger"
-version = "4.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f7/ff/3cc9165fd44106973cd7ac9facb674a65ed853494592541d339bdc9a30eb/python_json_logger-4.1.0.tar.gz", hash = "sha256:b396b9e3ed782b09ff9d6e4f1683d46c83ad0d35d2e407c09a9ebbf038f88195", size = 17573 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/be/0631a861af4d1c875f096c07d34e9a63639560a717130e7a87cbc82b7e3f/python_json_logger-4.1.0-py3-none-any.whl", hash = "sha256:132994765cf75bf44554be9aa49b06ef2345d23661a96720262716438141b6b2", size = 15021 },
 ]
 
 [[package]]
@@ -2408,30 +1911,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/49/0e/3f0d0d335c6b3abb9b7b723776d0b21fa7f3a6c819a0db6097059aada160/pyzmq-27.1.0-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:53b40f8ae006f2734ee7608d59ed661419f087521edbfc2149c3932e9c14808c", size = 567747 },
     { url = "https://files.pythonhosted.org/packages/a1/cf/f2b3784d536250ffd4be70e049f3b60981235d70c6e8ce7e3ef21e1adb25/pyzmq-27.1.0-pp311-pypy311_pp73-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f605d884e7c8be8fe1aa94e0a783bf3f591b84c24e4bc4f3e7564c82ac25e271", size = 747371 },
     { url = "https://files.pythonhosted.org/packages/01/1b/5dbe84eefc86f48473947e2f41711aded97eecef1231f4558f1f02713c12/pyzmq-27.1.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:c9f7f6e13dff2e44a6afeaf2cf54cee5929ad64afaf4d40b50f93c58fc687355", size = 544862 },
-]
-
-[[package]]
-name = "ray"
-version = "2.55.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click", marker = "sys_platform == 'linux'" },
-    { name = "filelock", marker = "sys_platform == 'linux'" },
-    { name = "jsonschema", marker = "sys_platform == 'linux'" },
-    { name = "msgpack", marker = "sys_platform == 'linux'" },
-    { name = "packaging", marker = "sys_platform == 'linux'" },
-    { name = "protobuf", marker = "sys_platform == 'linux'" },
-    { name = "pyyaml", marker = "sys_platform == 'linux'" },
-    { name = "requests", marker = "sys_platform == 'linux'" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/59/41da0e72a59cd3e8978480ccfeb86ef4235ae5ceb9b8928168a764fa930a/ray-2.55.1-cp311-cp311-manylinux2014_x86_64.whl", hash = "sha256:d5382da181c03ee2f502ef46cf0ae4bbc30157b5bd9a67d7651f6a272528a85a", size = 73706515 },
-    { url = "https://files.pythonhosted.org/packages/4c/f8/fffadf3f4285eebd460e4d7f2ed1c0cd641ed89613c3f49eb881ee9fa7e2/ray-2.55.1-cp312-cp312-manylinux2014_x86_64.whl", hash = "sha256:263705f6bab29e7622a94f82da25fd7f9cead76cdf89a07aab28f79cdf8f9d95", size = 73765203 },
-]
-
-[package.optional-dependencies]
-cgraph = [
-    { name = "cupy-cuda12x", marker = "sys_platform == 'linux'" },
 ]
 
 [[package]]
@@ -2517,46 +1996,6 @@ wheels = [
 ]
 
 [[package]]
-name = "rich-toolkit"
-version = "0.19.10"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click", marker = "sys_platform == 'linux'" },
-    { name = "rich", marker = "sys_platform == 'linux'" },
-    { name = "typing-extensions", marker = "sys_platform == 'linux'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/fa/02/32217f3657ae91a0ea7cf1d74ade78f44352f830d00c468f753ddb3d4980/rich_toolkit-0.19.10.tar.gz", hash = "sha256:dc2e8c515ef9fbb4894e62bd41a2d2960dd7c2f505b5084894604d5ccfee3f09", size = 198167 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/35/84/a005adcb4d1e6846ba3d62768090c3b943e3f6d8dc5c47af64f33584c4a7/rich_toolkit-0.19.10-py3-none-any.whl", hash = "sha256:93a41f67a09aefe90379f1729495c2fee9ccbcc8cfda48e2ca2ae54a995e32b1", size = 33907 },
-]
-
-[[package]]
-name = "rignore"
-version = "0.7.6"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e5/f5/8bed2310abe4ae04b67a38374a4d311dd85220f5d8da56f47ae9361be0b0/rignore-0.7.6.tar.gz", hash = "sha256:00d3546cd793c30cb17921ce674d2c8f3a4b00501cb0e3dd0e82217dbeba2671", size = 57140 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/c9/390a8fdfabb76d71416be773bd9f162977bd483084f68daf19da1dec88a6/rignore-0.7.6-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ba5524f5178deca4d7695e936604ebc742acb8958f9395776e1fcb8133f8257a", size = 873633 },
-    { url = "https://files.pythonhosted.org/packages/df/c9/79404fcb0faa76edfbc9df0901f8ef18568d1104919ebbbad6d608c888d1/rignore-0.7.6-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:62020dbb89a1dd4b84ab3d60547b3b2eb2723641d5fb198463643f71eaaed57d", size = 1167633 },
-    { url = "https://files.pythonhosted.org/packages/6e/8d/b3466d32d445d158a0aceb80919085baaae495b1f540fb942f91d93b5e5b/rignore-0.7.6-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b34acd532769d5a6f153a52a98dcb81615c949ab11697ce26b2eb776af2e174d", size = 941434 },
-    { url = "https://files.pythonhosted.org/packages/e8/40/9cd949761a7af5bc27022a939c91ff622d29c7a0b66d0c13a863097dde2d/rignore-0.7.6-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1c5e53b752f9de44dff7b3be3c98455ce3bf88e69d6dc0cf4f213346c5e3416c", size = 959461 },
-    { url = "https://files.pythonhosted.org/packages/17/18/162eedadb4c2282fa4c521700dbf93c9b14b8842e8354f7d72b445b8d593/rignore-0.7.6-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:5991e46ab9b4868334c9e372ab0892b0150f3f586ff2b1e314272caeb38aaedb", size = 1139012 },
-    { url = "https://files.pythonhosted.org/packages/9f/22/1c1a65047df864def9a047dbb40bc0b580b8289a4280e62779cd61ae21f2/rignore-0.7.6-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:aaf938530dcc0b47c4cfa52807aa2e5bfd5ca6d57a621125fe293098692f6345", size = 1128182 },
-    { url = "https://files.pythonhosted.org/packages/b3/2b/ee96db17ac1835e024c5d0742eefb7e46de60020385ac883dd3d1cde2c1f/rignore-0.7.6-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b5fd5ab3840b8c16851d327ed06e9b8be6459702a53e5ab1fc4073b684b3789e", size = 873963 },
-    { url = "https://files.pythonhosted.org/packages/a5/8c/ad5a57bbb9d14d5c7e5960f712a8a0b902472ea3f4a2138cbf70d1777b75/rignore-0.7.6-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ced2a248352636a5c77504cb755dc02c2eef9a820a44d3f33061ce1bb8a7f2d2", size = 1169216 },
-    { url = "https://files.pythonhosted.org/packages/80/e6/5b00bc2a6bc1701e6878fca798cf5d9125eb3113193e33078b6fc0d99123/rignore-0.7.6-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a04a3b73b75ddc12c9c9b21efcdaab33ca3832941d6f1d67bffd860941cd448a", size = 942942 },
-    { url = "https://files.pythonhosted.org/packages/85/e5/7f99bd0cc9818a91d0e8b9acc65b792e35750e3bdccd15a7ee75e64efca4/rignore-0.7.6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d24321efac92140b7ec910ac7c53ab0f0c86a41133d2bb4b0e6a7c94967f44dd", size = 959787 },
-    { url = "https://files.pythonhosted.org/packages/d4/cf/2c64f0b6725149f7c6e7e5a909d14354889b4beaadddaa5fff023ec71084/rignore-0.7.6-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:5719ea14ea2b652c0c0894be5dfde954e1853a80dea27dd2fbaa749618d837f5", size = 1139186 },
-    { url = "https://files.pythonhosted.org/packages/7f/5e/13b249613fd5d18d58662490ab910a9f0be758981d1797789913adb4e918/rignore-0.7.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3efdcf1dd84d45f3e2bd2f93303d9be103888f56dfa7c3349b5bf4f0657ec696", size = 1127725 },
-    { url = "https://files.pythonhosted.org/packages/55/e4/b3c5dfdd8d8a10741dfe7199ef45d19a0e42d0c13aa377c83bd6caf65d90/rignore-0.7.6-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:53fb28882d2538cb2d231972146c4927a9d9455e62b209f85d634408c4103538", size = 874843 },
-    { url = "https://files.pythonhosted.org/packages/cc/10/d6f3750233881a2a154cefc9a6a0a9b19da526b19f7f08221b552c6f827d/rignore-0.7.6-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:87409f7eeb1103d6b77f3472a3a0d9a5953e3ae804a55080bdcb0120ee43995b", size = 1170348 },
-    { url = "https://files.pythonhosted.org/packages/6e/10/ad98ca05c9771c15af734cee18114a3c280914b6e34fde9ffea2e61e88aa/rignore-0.7.6-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:684014e42e4341ab3ea23a203551857fcc03a7f8ae96ca3aefb824663f55db32", size = 942315 },
-    { url = "https://files.pythonhosted.org/packages/de/00/ab5c0f872acb60d534e687e629c17e0896c62da9b389c66d3aa16b817aa8/rignore-0.7.6-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:77356ebb01ba13f8a425c3d30fcad40e57719c0e37670d022d560884a30e4767", size = 961047 },
-    { url = "https://files.pythonhosted.org/packages/67/56/36d5d34210e5e7dfcd134eed8335b19e80ae940ee758f493e4f2b344dd70/rignore-0.7.6-pp311-pypy311_pp73-musllinux_1_2_armv7l.whl", hash = "sha256:c081f17290d8a2b96052b79207622aa635686ea39d502b976836384ede3d303c", size = 1139789 },
-    { url = "https://files.pythonhosted.org/packages/ce/8b/a1299085b28a2f6135e30370b126e3c5055b61908622f2488ade67641479/rignore-0.7.6-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:d8955b57e42f2a5434670d5aa7b75eaf6e74602ccd8955dddf7045379cd762fb", size = 1129444 },
-]
-
-[[package]]
 name = "rpds-py"
 version = "2026.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2605,21 +2044,6 @@ wheels = [
 ]
 
 [[package]]
-name = "scipy"
-version = "1.17.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy", marker = "sys_platform == 'linux'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/09/7d/af933f0f6e0767995b4e2d705a0665e454d1c19402aa7e895de3951ebb04/scipy-1.17.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43af8d1f3bea642559019edfe64e9b11192a8978efbd1539d7bc2aaa23d92de4", size = 35349300 },
-    { url = "https://files.pythonhosted.org/packages/e8/19/f926cb11c42b15ba08e3a71e376d816ac08614f769b4f47e06c3580c836a/scipy-1.17.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:4eb6c25dd62ee8d5edf68a8e1c171dd71c292fdae95d8aeb3dd7d7de4c364082", size = 37741314 },
-    { url = "https://files.pythonhosted.org/packages/01/8e/1e35281b8ab6d5d72ebe9911edcdffa3f36b04ed9d51dec6dd140396e220/scipy-1.17.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:02ae3b274fde71c5e92ac4d54bc06c42d80e399fec704383dcd99b301df37458", size = 35235890 },
-    { url = "https://files.pythonhosted.org/packages/65/94/7698add8f276dbab7a9de9fb6b0e02fc13ee61d51c7c3f85ac28b65e1239/scipy-1.17.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f590cd684941912d10becc07325a3eeb77886fe981415660d9265c4c418d0bea", size = 37625856 },
-]
-
-[[package]]
 name = "sentencepiece"
 version = "0.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2648,29 +2072,15 @@ version = "1.3.7"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8d/48/49393a96a2eef1ab418b17475fb92b8fcfad83d099e678751b05472e69de/setproctitle-1.3.7.tar.gz", hash = "sha256:bc2bc917691c1537d5b9bca1468437176809c7e11e5694ca79a9ca12345dcb9e", size = 27002 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/cd/1b7ba5cad635510720ce19d7122154df96a2387d2a74217be552887c93e5/setproctitle-1.3.7-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:a600eeb4145fb0ee6c287cb82a2884bd4ec5bbb076921e287039dcc7b7cc6dd0", size = 18085 },
-    { url = "https://files.pythonhosted.org/packages/8f/1a/b2da0a620490aae355f9d72072ac13e901a9fec809a6a24fc6493a8f3c35/setproctitle-1.3.7-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:97a090fed480471bb175689859532709e28c085087e344bca45cf318034f70c4", size = 13097 },
     { url = "https://files.pythonhosted.org/packages/18/2e/bd03ff02432a181c1787f6fc2a678f53b7dacdd5ded69c318fe1619556e8/setproctitle-1.3.7-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:1607b963e7b53e24ec8a2cb4e0ab3ae591d7c6bf0a160feef0551da63452b37f", size = 32191 },
-    { url = "https://files.pythonhosted.org/packages/28/78/1e62fc0937a8549f2220445ed2175daacee9b6764c7963b16148119b016d/setproctitle-1.3.7-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a20fb1a3974e2dab857870cf874b325b8705605cb7e7e8bcbb915bca896f52a9", size = 33203 },
     { url = "https://files.pythonhosted.org/packages/a0/3c/65edc65db3fa3df400cf13b05e9d41a3c77517b4839ce873aa6b4043184f/setproctitle-1.3.7-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f8d961bba676e07d77665204f36cffaa260f526e7b32d07ab3df6a2c1dfb44ba", size = 34963 },
-    { url = "https://files.pythonhosted.org/packages/a1/32/89157e3de997973e306e44152522385f428e16f92f3cf113461489e1e2ee/setproctitle-1.3.7-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:db0fd964fbd3a9f8999b502f65bd2e20883fdb5b1fae3a424e66db9a793ed307", size = 32398 },
     { url = "https://files.pythonhosted.org/packages/4a/18/77a765a339ddf046844cb4513353d8e9dcd8183da9cdba6e078713e6b0b2/setproctitle-1.3.7-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:db116850fcf7cca19492030f8d3b4b6e231278e8fe097a043957d22ce1bdf3ee", size = 33657 },
     { url = "https://files.pythonhosted.org/packages/6b/63/f0b6205c64d74d2a24a58644a38ec77bdbaa6afc13747e75973bf8904932/setproctitle-1.3.7-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:316664d8b24a5c91ee244460bdaf7a74a707adaa9e14fbe0dc0a53168bb9aba1", size = 31836 },
-    { url = "https://files.pythonhosted.org/packages/ba/51/e1277f9ba302f1a250bbd3eedbbee747a244b3cc682eb58fb9733968f6d8/setproctitle-1.3.7-cp311-cp311-win32.whl", hash = "sha256:b74774ca471c86c09b9d5037c8451fff06bb82cd320d26ae5a01c758088c0d5d", size = 12556 },
-    { url = "https://files.pythonhosted.org/packages/b6/7b/822a23f17e9003dfdee92cd72758441ca2a3680388da813a371b716fb07f/setproctitle-1.3.7-cp311-cp311-win_amd64.whl", hash = "sha256:acb9097213a8dd3410ed9f0dc147840e45ca9797785272928d4be3f0e69e3be4", size = 13243 },
-    { url = "https://files.pythonhosted.org/packages/fb/f0/2dc88e842077719d7384d86cc47403e5102810492b33680e7dadcee64cd8/setproctitle-1.3.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:2dc99aec591ab6126e636b11035a70991bc1ab7a261da428491a40b84376654e", size = 18049 },
-    { url = "https://files.pythonhosted.org/packages/f0/b4/50940504466689cda65680c9e9a1e518e5750c10490639fa687489ac7013/setproctitle-1.3.7-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:cdd8aa571b7aa39840fdbea620e308a19691ff595c3a10231e9ee830339dd798", size = 13079 },
     { url = "https://files.pythonhosted.org/packages/d0/99/71630546b9395b095f4082be41165d1078204d1696c2d9baade3de3202d0/setproctitle-1.3.7-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2906b6c7959cdb75f46159bf0acd8cc9906cf1361c9e1ded0d065fe8f9039629", size = 32932 },
-    { url = "https://files.pythonhosted.org/packages/50/22/cee06af4ffcfb0e8aba047bd44f5262e644199ae7527ae2c1f672b86495c/setproctitle-1.3.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6915964a6dda07920a1159321dcd6d94fc7fc526f815ca08a8063aeca3c204f1", size = 33736 },
     { url = "https://files.pythonhosted.org/packages/5c/00/a5949a8bb06ef5e7df214fc393bb2fb6aedf0479b17214e57750dfdd0f24/setproctitle-1.3.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cff72899861c765bd4021d1ff1c68d60edc129711a2fdba77f9cb69ef726a8b6", size = 35605 },
-    { url = "https://files.pythonhosted.org/packages/b0/3a/50caca532a9343828e3bf5778c7a84d6c737a249b1796d50dd680290594d/setproctitle-1.3.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b7cb05bd446687ff816a3aaaf831047fc4c364feff7ada94a66024f1367b448c", size = 33143 },
     { url = "https://files.pythonhosted.org/packages/ca/14/b843a251296ce55e2e17c017d6b9f11ce0d3d070e9265de4ecad948b913d/setproctitle-1.3.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:3a57b9a00de8cae7e2a1f7b9f0c2ac7b69372159e16a7708aa2f38f9e5cc987a", size = 34434 },
     { url = "https://files.pythonhosted.org/packages/c8/b7/06145c238c0a6d2c4bc881f8be230bb9f36d2bf51aff7bddcb796d5eed67/setproctitle-1.3.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:d8828b356114f6b308b04afe398ed93803d7fca4a955dd3abe84430e28d33739", size = 32795 },
-    { url = "https://files.pythonhosted.org/packages/ef/dc/ef76a81fac9bf27b84ed23df19c1f67391a753eed6e3c2254ebcb5133f56/setproctitle-1.3.7-cp312-cp312-win32.whl", hash = "sha256:b0304f905efc845829ac2bc791ddebb976db2885f6171f4a3de678d7ee3f7c9f", size = 12552 },
-    { url = "https://files.pythonhosted.org/packages/e2/5b/a9fe517912cd6e28cf43a212b80cb679ff179a91b623138a99796d7d18a0/setproctitle-1.3.7-cp312-cp312-win_amd64.whl", hash = "sha256:9888ceb4faea3116cf02a920ff00bfbc8cc899743e4b4ac914b03625bdc3c300", size = 13247 },
-    { url = "https://files.pythonhosted.org/packages/c3/5b/5e1c117ac84e3cefcf8d7a7f6b2461795a87e20869da065a5c087149060b/setproctitle-1.3.7-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:b1cac6a4b0252b8811d60b6d8d0f157c0fdfed379ac89c25a914e6346cf355a1", size = 12587 },
     { url = "https://files.pythonhosted.org/packages/73/02/b9eadc226195dcfa90eed37afe56b5dd6fa2f0e5220ab8b7867b8862b926/setproctitle-1.3.7-pp311-pypy311_pp73-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f1704c9e041f2b1dc38f5be4552e141e1432fba3dd52c72eeffd5bc2db04dc65", size = 14286 },
-    { url = "https://files.pythonhosted.org/packages/28/26/1be1d2a53c2a91ec48fa2ff4a409b395f836798adf194d99de9c059419ea/setproctitle-1.3.7-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:b08b61976ffa548bd5349ce54404bf6b2d51bd74d4f1b241ed1b0f25bce09c3a", size = 13282 },
 ]
 
 [[package]]
@@ -2683,12 +2093,66 @@ wheels = [
 ]
 
 [[package]]
-name = "shellingham"
-version = "1.5.4"
+name = "sgl-kernel"
+version = "0.1.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755 },
+    { url = "https://files.pythonhosted.org/packages/da/74/d804e757d7dd85aecdd534429d9335ce87b881a1601341c01a39f9b256fd/sgl_kernel-0.1.4-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:330fb1cdf0952c1e0a77f93540bf2ba2c8b424e75768e4d64438027346d314dc", size = 231504246 },
+]
+
+[[package]]
+name = "sglang"
+version = "0.4.6.post5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp", marker = "sys_platform == 'linux'" },
+    { name = "ipython", marker = "sys_platform == 'linux'" },
+    { name = "numpy", marker = "sys_platform == 'linux'" },
+    { name = "requests", marker = "sys_platform == 'linux'" },
+    { name = "setproctitle", marker = "sys_platform == 'linux'" },
+    { name = "tqdm", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/40/1f/3ac1eb0ea3962e0281b368a97b1f85c0735cce31c6a6efb22b1ceb57c160/sglang-0.4.6.post5.tar.gz", hash = "sha256:eef53ceb2d60d85a68d81f1ab844899d43f73fbbcd3add040d585446936dcfda", size = 997139 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/53/a52eb53f91d4b7d2de1401bf91d83f7bf50453d81a89d5a19aab14cd624a/sglang-0.4.6.post5-py3-none-any.whl", hash = "sha256:2a48053bd975e09ff10eabf1ef8bab4c913f3c3e16a3e45c13be1b4543cfeaed", size = 1393672 },
+]
+
+[package.optional-dependencies]
+srt = [
+    { name = "blobfile", marker = "sys_platform == 'linux'" },
+    { name = "compressed-tensors", marker = "sys_platform == 'linux'" },
+    { name = "cuda-python", marker = "sys_platform == 'linux'" },
+    { name = "datasets", marker = "sys_platform == 'linux'" },
+    { name = "einops", marker = "sys_platform == 'linux'" },
+    { name = "fastapi", marker = "sys_platform == 'linux'" },
+    { name = "flashinfer-python", marker = "sys_platform == 'linux'" },
+    { name = "hf-transfer", marker = "sys_platform == 'linux'" },
+    { name = "huggingface-hub", marker = "sys_platform == 'linux'" },
+    { name = "interegular", marker = "sys_platform == 'linux'" },
+    { name = "llguidance", marker = "sys_platform == 'linux'" },
+    { name = "modelscope", marker = "sys_platform == 'linux'" },
+    { name = "msgspec", marker = "sys_platform == 'linux'" },
+    { name = "ninja", marker = "sys_platform == 'linux'" },
+    { name = "orjson", marker = "sys_platform == 'linux'" },
+    { name = "outlines", marker = "sys_platform == 'linux'" },
+    { name = "packaging", marker = "sys_platform == 'linux'" },
+    { name = "partial-json-parser", marker = "sys_platform == 'linux'" },
+    { name = "pillow", marker = "sys_platform == 'linux'" },
+    { name = "prometheus-client", marker = "sys_platform == 'linux'" },
+    { name = "psutil", marker = "sys_platform == 'linux'" },
+    { name = "pydantic", marker = "sys_platform == 'linux'" },
+    { name = "pynvml", marker = "sys_platform == 'linux'" },
+    { name = "python-multipart", marker = "sys_platform == 'linux'" },
+    { name = "pyzmq", marker = "sys_platform == 'linux'" },
+    { name = "sgl-kernel", marker = "sys_platform == 'linux'" },
+    { name = "soundfile", marker = "sys_platform == 'linux'" },
+    { name = "torch", marker = "sys_platform == 'linux'" },
+    { name = "torchao", marker = "sys_platform == 'linux'" },
+    { name = "torchvision", marker = "sys_platform == 'linux'" },
+    { name = "transformers", marker = "sys_platform == 'linux'" },
+    { name = "uvicorn", marker = "sys_platform == 'linux'" },
+    { name = "uvloop", marker = "sys_platform == 'linux'" },
+    { name = "xgrammar", marker = "sys_platform == 'linux'" },
 ]
 
 [[package]]
@@ -2719,12 +2183,17 @@ wheels = [
 ]
 
 [[package]]
-name = "sniffio"
-version = "1.3.1"
+name = "soundfile"
+version = "0.13.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372 }
+dependencies = [
+    { name = "cffi", marker = "sys_platform == 'linux'" },
+    { name = "numpy", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e1/41/9b873a8c055582859b239be17902a85339bec6a30ad162f98c9b0288a2cc/soundfile-0.13.1.tar.gz", hash = "sha256:b2c68dab1e30297317080a5b43df57e302584c49e2942defdde0acccc53f0e5b", size = 46156 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235 },
+    { url = "https://files.pythonhosted.org/packages/64/28/e2a36573ccbcf3d57c00626a21fe51989380636e821b341d36ccca0c1c3a/soundfile-0.13.1-py2.py3-none-any.whl", hash = "sha256:a23c717560da2cf4c7b5ae1142514e0fd82d6bbd9dfc93a50423447142f2c445", size = 25751 },
+    { url = "https://files.pythonhosted.org/packages/57/5e/70bdd9579b35003a489fc850b5047beeda26328053ebadc1fb60f320f7db/soundfile-0.13.1-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:03267c4e493315294834a0870f31dbb3b28a95561b80b134f0bd3cf2d5f0e618", size = 1313646 },
 ]
 
 [[package]]
@@ -2867,15 +2336,12 @@ wheels = [
 ]
 
 [[package]]
-name = "torchaudio"
-version = "2.6.0"
+name = "torchao"
+version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "torch", marker = "sys_platform == 'linux'" },
-]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3e/00/2c69d436c613043f3051210d2f84a4c9062a815fa609c5f54d25ea8bfd07/torchaudio-2.6.0-cp311-cp311-manylinux1_x86_64.whl", hash = "sha256:377b177a3d683a9163e4cab5a06f0346dac9ff96fa527477338fd90fc6a2a4b6", size = 3382518 },
-    { url = "https://files.pythonhosted.org/packages/ed/aa/9082e715a673dd8e22b6a60cec7f301e897406023672b2090f8bcd8a5959/torchaudio-2.6.0-cp312-cp312-manylinux1_x86_64.whl", hash = "sha256:715aa21f6bdbd085454c313ae3a2c7cc07bf2e8cf05752f819afb5b4c57f4e6f", size = 3379510 },
+    { url = "https://files.pythonhosted.org/packages/7d/fe/a24225d30775192a4c5d9cea3ecb95e6adc69d0a8b5ed98eb8e58d362344/torchao-0.9.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bc708910301a9f98344d43f3fe2aa6d5e1fab706d772b6df47ff05087d664145", size = 5652091 },
+    { url = "https://files.pythonhosted.org/packages/db/72/01f755514fb61eadc80b974eb4bd4f22f3009b35457773523e3bd497c511/torchao-0.9.0-py3-none-any.whl", hash = "sha256:ea5603c32762f1a9ade1a4dc7b00f5246623b24a28e49e666f614c79a408712a", size = 712541 },
 ]
 
 [[package]]
@@ -2932,7 +2398,7 @@ wheels = [
 
 [[package]]
 name = "transformers"
-version = "4.51.3"
+version = "4.51.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
@@ -2946,9 +2412,9 @@ dependencies = [
     { name = "tokenizers" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f1/11/7414d5bc07690002ce4d7553602107bf969af85144bbd02830f9fb471236/transformers-4.51.3.tar.gz", hash = "sha256:e292fcab3990c6defe6328f0f7d2004283ca81a7a07b2de9a46d67fd81ea1409", size = 8941266 }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/85/9182a14e0cceb6ababd37c9832d99f1c939e89854c80fa676ee0dbb8615b/transformers-4.51.1.tar.gz", hash = "sha256:206ea0b75dfde142ed7495b911da76579dce6ea249cc3695fdd29a544a9e007b", size = 8935230 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a9/b6/5257d04ae327b44db31f15cce39e6020cc986333c715660b1315a9724d82/transformers-4.51.3-py3-none-any.whl", hash = "sha256:fd3279633ceb2b777013234bbf0b4f5c2d23c4626b05497691f00cfda55e8a83", size = 10383940 },
+    { url = "https://files.pythonhosted.org/packages/73/e0/f1fce1b2f31da4acfb858732d909209fdb10f65adda1e7af0c7ac74927a5/transformers-4.51.1-py3-none-any.whl", hash = "sha256:c7038e216afb2a3e9b00dd12d87ad5e3af4c30895f70b28e92f65459eded0161", size = 10365727 },
 ]
 
 [[package]]
@@ -3007,20 +2473,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/67/1c/dfba5c4633cafc4c701f237d2ba63b416805047fd6d96aab4cfc40969f98/typeguard-4.5.2.tar.gz", hash = "sha256:5a16dcac23502039299c97c8941651bc33d7ea8cc4b2f7d6bbb1b528f6eea423", size = 80240 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/29/74eeb4d3f3ae61ca096b018ad486b3b3c74b17bec09ab4edab721cbefec3/typeguard-4.5.2-py3-none-any.whl", hash = "sha256:fcf9de18bd945cdb4c7b996e12b4c51ce83f92f191314a6d7cf1739586ec98cf", size = 36748 },
-]
-
-[[package]]
-name = "typer"
-version = "0.26.5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "annotated-doc", marker = "sys_platform == 'linux'" },
-    { name = "rich", marker = "sys_platform == 'linux'" },
-    { name = "shellingham", marker = "sys_platform == 'linux'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/eb/1a/2cf40b65b1d9c254fe5814bb0519f9b8f2ac38059df0810f9b866300c04a/typer-0.26.5.tar.gz", hash = "sha256:9b9b39e35c3afc9e1e51a06f21155246e457c0911279b09b35d8210ca74b935c", size = 201494 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/d6/baac76fc04a6532883de3d8722c7f921dae94d10965e7ffba9e38e42a251/typer-0.26.5-py3-none-any.whl", hash = "sha256:4bfd901d564e41608920134aa5d4481200f4ba76d98e982d9f9d32dcb7b84da0", size = 122451 },
 ]
 
 [[package]]
@@ -3119,16 +2571,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/01/be/72532be3da7acc5fdfbccdb95215cd04f995a0886532a5b423f929cda4cc/uvicorn-0.48.0-py3-none-any.whl", hash = "sha256:48097851328b87ec36117d3d575234519eb58c2b22d79666e9bbc6c49a761dad", size = 71410 },
 ]
 
-[package.optional-dependencies]
-standard = [
-    { name = "httptools", marker = "sys_platform == 'linux'" },
-    { name = "python-dotenv", marker = "sys_platform == 'linux'" },
-    { name = "pyyaml", marker = "sys_platform == 'linux'" },
-    { name = "uvloop", marker = "platform_python_implementation != 'PyPy' and sys_platform == 'linux'" },
-    { name = "watchfiles", marker = "sys_platform == 'linux'" },
-    { name = "websockets", marker = "sys_platform == 'linux'" },
-]
-
 [[package]]
 name = "uvloop"
 version = "0.22.1"
@@ -3142,102 +2584,32 @@ wheels = [
 ]
 
 [[package]]
-name = "vllm"
-version = "0.8.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "aiohttp", marker = "sys_platform == 'linux'" },
-    { name = "blake3", marker = "sys_platform == 'linux'" },
-    { name = "cachetools", marker = "sys_platform == 'linux'" },
-    { name = "cloudpickle", marker = "sys_platform == 'linux'" },
-    { name = "compressed-tensors", marker = "sys_platform == 'linux'" },
-    { name = "depyf", marker = "sys_platform == 'linux'" },
-    { name = "einops", marker = "sys_platform == 'linux'" },
-    { name = "fastapi", extra = ["standard"], marker = "sys_platform == 'linux'" },
-    { name = "filelock", marker = "sys_platform == 'linux'" },
-    { name = "gguf", marker = "sys_platform == 'linux'" },
-    { name = "huggingface-hub", extra = ["hf-xet"], marker = "sys_platform == 'linux'" },
-    { name = "importlib-metadata", marker = "sys_platform == 'linux'" },
-    { name = "lark", marker = "sys_platform == 'linux'" },
-    { name = "llguidance", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'arm64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "lm-format-enforcer", marker = "sys_platform == 'linux'" },
-    { name = "mistral-common", extra = ["opencv"], marker = "sys_platform == 'linux'" },
-    { name = "msgspec", marker = "sys_platform == 'linux'" },
-    { name = "ninja", marker = "sys_platform == 'linux'" },
-    { name = "numba", marker = "sys_platform == 'linux'" },
-    { name = "numpy", marker = "sys_platform == 'linux'" },
-    { name = "openai", marker = "sys_platform == 'linux'" },
-    { name = "opencv-python-headless", marker = "sys_platform == 'linux'" },
-    { name = "opentelemetry-api", marker = "sys_platform == 'linux'" },
-    { name = "opentelemetry-exporter-otlp", marker = "sys_platform == 'linux'" },
-    { name = "opentelemetry-sdk", marker = "sys_platform == 'linux'" },
-    { name = "opentelemetry-semantic-conventions-ai", marker = "sys_platform == 'linux'" },
-    { name = "outlines", marker = "sys_platform == 'linux'" },
-    { name = "partial-json-parser", marker = "sys_platform == 'linux'" },
-    { name = "pillow", marker = "sys_platform == 'linux'" },
-    { name = "prometheus-client", marker = "sys_platform == 'linux'" },
-    { name = "prometheus-fastapi-instrumentator", marker = "sys_platform == 'linux'" },
-    { name = "protobuf", marker = "sys_platform == 'linux'" },
-    { name = "psutil", marker = "sys_platform == 'linux'" },
-    { name = "py-cpuinfo", marker = "sys_platform == 'linux'" },
-    { name = "pydantic", marker = "sys_platform == 'linux'" },
-    { name = "python-json-logger", marker = "sys_platform == 'linux'" },
-    { name = "pyyaml", marker = "sys_platform == 'linux'" },
-    { name = "pyzmq", marker = "sys_platform == 'linux'" },
-    { name = "ray", extra = ["cgraph"], marker = "sys_platform == 'linux'" },
-    { name = "requests", marker = "sys_platform == 'linux'" },
-    { name = "scipy", marker = "sys_platform == 'linux'" },
-    { name = "sentencepiece", marker = "sys_platform == 'linux'" },
-    { name = "setuptools", marker = "python_full_version >= '3.12' and sys_platform == 'linux'" },
-    { name = "six", marker = "python_full_version >= '3.12' and sys_platform == 'linux'" },
-    { name = "tiktoken", marker = "sys_platform == 'linux'" },
-    { name = "tokenizers", marker = "sys_platform == 'linux'" },
-    { name = "torch", marker = "sys_platform == 'linux'" },
-    { name = "torchaudio", marker = "sys_platform == 'linux'" },
-    { name = "torchvision", marker = "sys_platform == 'linux'" },
-    { name = "tqdm", marker = "sys_platform == 'linux'" },
-    { name = "transformers", marker = "sys_platform == 'linux'" },
-    { name = "typing-extensions", marker = "sys_platform == 'linux'" },
-    { name = "watchfiles", marker = "sys_platform == 'linux'" },
-    { name = "xformers", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "xgrammar", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e6/d6/9d412cdaa92c3ab6250cef51217d37395b2aa372c6c14f90b1668adbbf63/vllm-0.8.4.tar.gz", hash = "sha256:522b13dd16c6c773dec0cb4c42ea591623d03ef94d16db8128ece2600017e6ac", size = 6667631 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8e/cb/03dc1299e0456ff3d58a11f63682ef29aaf5b1bd7f21bfe0690d7ce6fc40/vllm-0.8.4-cp38-abi3-manylinux1_x86_64.whl", hash = "sha256:e346749ee8df48cdcd935d00a7fc123a1e17d9904b064401e74fc6ad73b8104a", size = 294098962 },
-]
-
-[[package]]
 name = "wandb"
-version = "0.19.9"
+version = "0.27.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
-    { name = "docker-pycreds" },
     { name = "gitpython" },
+    { name = "packaging" },
     { name = "platformdirs" },
     { name = "protobuf" },
-    { name = "psutil" },
     { name = "pydantic" },
     { name = "pyyaml" },
     { name = "requests" },
     { name = "sentry-sdk" },
-    { name = "setproctitle" },
-    { name = "setuptools" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5f/07/c4f4ace4445cfafcd6a35dff94e03b3b875f2e472ae524c1d32fec8a5c33/wandb-0.19.9.tar.gz", hash = "sha256:a38881aa7770e6ea0f792268250e5b888a245c2e4829e5830ce08f5fa95a2ad1", size = 39264462 }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/31/fe53d06b75ef0a7f2f0ee5931a89f7aedc27d233840b1839616860fed256/wandb-0.27.0.tar.gz", hash = "sha256:579e75300173059f9334e1f513a79ef15f6d9ea5c74e20d695633648cdd02031", size = 41090732 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ad/32/39de0bcf45f0026aabbc9dcd41c287dc21f62b5cb6fe054bbb3b988ff01c/wandb-0.19.9-py3-none-any.whl", hash = "sha256:191b2c794b401bd04cc7c48b16339ca2832510af8499348744e7461a1609b6a9", size = 6335646 },
-    { url = "https://files.pythonhosted.org/packages/c6/61/f37280987c4ef624e238be4cbad4a0ffe71987fbb75c029fc89c6bd849b7/wandb-0.19.9-py3-none-macosx_10_14_x86_64.whl", hash = "sha256:de5702416f29d1d61f9e85f4090346f23db1ee7f23cab37a4dd5d394fcf5f7da", size = 20468027 },
-    { url = "https://files.pythonhosted.org/packages/49/35/7af15563f7cc40c7ac95f2d2e5ca10fa144d1be20a62da8f475cc7ceebd3/wandb-0.19.9-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c598041f06be3cbed6bf6888cb67b033352ce156dc4e7882c4448e2750453a77", size = 19931553 },
-    { url = "https://files.pythonhosted.org/packages/f9/b2/aa02811d0eb66530e67c44cc1e7d001507064d54b036f2a801bc9c0a731f/wandb-0.19.9-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:7b99253c1f603d9331fa0626df61f47f0b544403321286c4fff50492572738f5", size = 20466642 },
-    { url = "https://files.pythonhosted.org/packages/56/07/47ab3b4f0f4a32d9269ecb60aa71da3e426faa2abe51c4f000778e2696c3/wandb-0.19.9-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8a074ad070c4e8cbb03b2149a98abbe2d7562220f095a21c736e1abbca399eef", size = 19534405 },
-    { url = "https://files.pythonhosted.org/packages/89/d0/737d26d709bd7bc3f6b2250f41fda3d0787239cfdbd6eb13057c64c81ace/wandb-0.19.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5dc6c7180a5bf1eb5bd9cab8a1886fd980c76d54253c967082fe19d197443a2d", size = 20863142 },
-    { url = "https://files.pythonhosted.org/packages/28/a5/420515e3f724d730ef830e2362aaa53ce49f366d919fbfa9ed4c3a148095/wandb-0.19.9-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:1e8cea987f326b053e79b7c40a0502c61a23792c9869b92ab6f2ac76086f66c2", size = 19545396 },
-    { url = "https://files.pythonhosted.org/packages/56/05/bab99791ede9eb78d03ddd27c54cbafcd89db1f279d4f4634156ebfcc24f/wandb-0.19.9-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:969a700cd625f56b2ac6c9e136ae828a0c3b2ebc4dc289c829986e9e7aded6bb", size = 20944223 },
-    { url = "https://files.pythonhosted.org/packages/07/ab/e3f728ff75307ba387546d3aedba7f18b4f5467d92d0343df2dee75af27e/wandb-0.19.9-py3-none-win32.whl", hash = "sha256:d3a192fec8fdfd89993243a81cad332c6c0e7127a9497b6bf9c244adeab2d717", size = 20247779 },
-    { url = "https://files.pythonhosted.org/packages/78/89/fee9e1513cc7045e9a6235b14d8e6e5b625fe4fe3a281fda9e799c6269ed/wandb-0.19.9-py3-none-win_amd64.whl", hash = "sha256:2033dacee312988e5418d0f257fd9888d28b6785ec39ec43cb2f6b8fd2f13176", size = 20247782 },
+    { url = "https://files.pythonhosted.org/packages/ea/5e/2c199e70e636ecfd217cde0bc7469f4511e1d03d0685eb92bfdfce391430/wandb-0.27.0-py3-none-macosx_12_0_arm64.whl", hash = "sha256:c156be4851485f3c4160cb6eb2e8991b4cdeffbccefc5636d33cf5e254847365", size = 24886476 },
+    { url = "https://files.pythonhosted.org/packages/0b/cd/a617c871cd304a9804e56a7ec2ec2c65685bf0091a2b9f91910175a149e2/wandb-0.27.0-py3-none-macosx_12_0_x86_64.whl", hash = "sha256:20179f38afb0158859a4141d29ac650d3fdbd0cf801a74ce25565c934f03776c", size = 26045779 },
+    { url = "https://files.pythonhosted.org/packages/10/0a/d3f159a201530b84b72ca5f98c68d1f351c2d9a1864558ed76c811407fae/wandb-0.27.0-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:626497d7975fa898d0a4a239da7a510483495ca3514510dbe75004a25963af4d", size = 25480764 },
+    { url = "https://files.pythonhosted.org/packages/5f/6a/8721fcdf71d42639191040a77a585d2982402b1754700cb2ecfc2ca1470a/wandb-0.27.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:f772da7005cc26a2a32b729a16982a583dc68b3d493df6a09d0aa5c5ca5a2060", size = 27256204 },
+    { url = "https://files.pythonhosted.org/packages/00/5e/279d167ba79fb7a8a43401c9f25efd0f6663ee9bd1eaf5a8578530198888/wandb-0.27.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:63acfc5b994e4a90e4a2fbdee6d45e664da3dd865bb1419942c8995c06c41cf1", size = 25647469 },
+    { url = "https://files.pythonhosted.org/packages/94/51/a69ac59300e3c813939d0764348959ed2a21e14c668cb1cebcb04010da6a/wandb-0.27.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:17aae6e4a88cd05c00ea8f546220918e3ebb6f8c1c36b70ef04a5ac75f0d7160", size = 27599005 },
+    { url = "https://files.pythonhosted.org/packages/5f/40/bf510c8758727df020f83b717ebc1fcc1739ed7f6ae1796ebef60bf6f592/wandb-0.27.0-py3-none-win32.whl", hash = "sha256:0bd5659417e386bf6538b5e2ffe6885774c6197f0e4853bfed517d5b0db457f1", size = 25036164 },
+    { url = "https://files.pythonhosted.org/packages/54/ff/69f88e7d90c22b79bcb911143c13e59742ee192080b21015ff83a5a1f60a/wandb-0.27.0-py3-none-win_amd64.whl", hash = "sha256:89d584b73166eecee96fb446f18d0e45b1aa45aba6a3696296f3f06d7454516b", size = 25036170 },
+    { url = "https://files.pythonhosted.org/packages/f6/38/f7efd7a87297a55c7e9a331a1dbb5b19e54aeacc11fe6f43f8636a73987c/wandb-0.27.0-py3-none-win_arm64.whl", hash = "sha256:a6c129c311edf210a2b4f2f4acc557eff522628125f5f28ed27df19c16c07079", size = 22972710 },
 ]
 
 [[package]]
@@ -3293,53 +2665,8 @@ wheels = [
 ]
 
 [[package]]
-name = "websockets"
-version = "16.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/04/24/4b2031d72e840ce4c1ccb255f693b15c334757fc50023e4db9537080b8c4/websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5", size = 179346 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/ae/0ee92b33087a33632f37a635e11e1d99d429d3d323329675a6022312aac2/websockets-16.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:08d7af67b64d29823fed316505a89b86705f2b7981c07848fb5e3ea3020c1abe", size = 184631 },
-    { url = "https://files.pythonhosted.org/packages/6d/e2/d5332c90da12b1e01f06fb1b85c50cfc489783076547415bf9f0a659ec19/websockets-16.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1c1b30e4f497b0b354057f3467f56244c603a79c0d1dafce1d16c283c25f6e64", size = 184615 },
-    { url = "https://files.pythonhosted.org/packages/18/29/71729b4671f21e1eaa5d6573031ab810ad2936c8175f03f97f3ff164c802/websockets-16.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9b5aca38b67492ef518a8ab76851862488a478602229112c4b0d58d63a7a4d5c", size = 184915 },
-    { url = "https://files.pythonhosted.org/packages/47/88/4dd516068e1a3d6ab3c7c183288404cd424a9a02d585efbac226cb61ff2d/websockets-16.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:485c49116d0af10ac698623c513c1cc01c9446c058a4e61e3bf6c19dff7335a2", size = 184880 },
-    { url = "https://files.pythonhosted.org/packages/56/0c/2dbf513bafd24889d33de2ff0368190a0e69f37bcfa19009ef819fe4d507/websockets-16.0-pp311-pypy311_pp73-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f4a32d1bd841d4bcbffdcb3d2ce50c09c3909fbead375ab28d0181af89fd04da", size = 176071 },
-    { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598 },
-]
-
-[[package]]
-name = "wrapt"
-version = "2.2.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2d/9f/06263fcd8ad6c405f05a3905fd7a84dd3176eb5ad46e44bccc0cd16348bb/wrapt-2.2.1.tar.gz", hash = "sha256:6744f504375775d7609c82c8d3d94af1c9a6f05586984536905908ba905277b9", size = 127620 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6e/fd/c0cac1f77c9c4f6fe58a920ca632ce379bb8be928720e11e8d73de28a5e9/wrapt-2.2.1-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9a04c28c10ba7fd12842b109d2edb0678872a2fe65277ca4ff06a0d61edee245", size = 159208 },
-    { url = "https://files.pythonhosted.org/packages/d6/95/b7cd9a22a06cf93e6482904ee6afc956248983553593fd1009296d1b3b31/wrapt-2.2.1-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ac2745950b2bff80219c15ebf2fa9d8427eba7e249739f97e55c9d169e47e9e1", size = 153243 },
-    { url = "https://files.pythonhosted.org/packages/ec/dc/435015b58ce33c6fc4104158fa91ddb0e809ab03a5751fb7465d1d461456/wrapt-2.2.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:c803a3d331796255af51ba2c79ed0ac8275865b516c09e61f248d1e7aff31ce9", size = 152351 },
-    { url = "https://files.pythonhosted.org/packages/77/ac/5d203f98df8fd136b95c5227139aea02d34505e18baf812d0c005df61963/wrapt-2.2.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:9b984d1eb252145d6302c1dbd5e87fc6d404d45531447c84eadec04bf1fcb027", size = 158347 },
-    { url = "https://files.pythonhosted.org/packages/17/93/fb357cc7847c58a8ae790be718903afa81a28d23e642c843dc4129e8a0b2/wrapt-2.2.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:61acce4257a9883669703c525447c5b4c392edf0f987ae77ec32668440158f0e", size = 169364 },
-    { url = "https://files.pythonhosted.org/packages/cd/87/ee3f32d5658e3e26d3e0e457922b47a36dd3bfbdfee7f97bb3e802344a66/wrapt-2.2.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:03df9ebed4c73ab93fa8c07e3d41d818dfca1852b15731a3de59457b27814624", size = 160205 },
-    { url = "https://files.pythonhosted.org/packages/b1/f3/2d541a060c5bbafb9400bca4917e4d78bfd1f239f404782c86831a8f6b29/wrapt-2.2.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:844c858fc3bb7eacc0ba8efa904935d16aac6a4470948ad1e7e55c9f5a2a665f", size = 158388 },
-    { url = "https://files.pythonhosted.org/packages/1d/68/8d92c8800c57e93cb116ae9e9d6cbafc34fade5ee9f9107b6f203fb4dc35/wrapt-2.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:87bacdaf225117a342a20d9c03438d701c02112f6e3f351ce9b7f32354f14797", size = 167682 },
-    { url = "https://files.pythonhosted.org/packages/53/46/29ac9daf11a86c22a8c38cd9236c62928ccae83f7ceb06bd3b0467cf9d05/wrapt-2.2.1-py3-none-any.whl", hash = "sha256:3aafea2975caef8ca49400640dde02cc7426e798f24870ed01f490bc3cffd32f", size = 61000 },
-]
-
-[[package]]
-name = "xformers"
-version = "0.0.29.post2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy", marker = "sys_platform == 'linux'" },
-    { name = "torch", marker = "sys_platform == 'linux'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/27/ed/04ec7ef97a7e1c836add41ef5a2aef8cbdd45c0190ca42cc08f3c21e2b7b/xformers-0.0.29.post2.tar.gz", hash = "sha256:6ca3d1a6db6f2abff25c1154adee96987f77f4dfd5141771805afa5fc13e9395", size = 8468494 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8d/a1/2433df25c425de6186f9359831cb0d401075810f473c5ba24beec2c51efc/xformers-0.0.29.post2-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:bbf0e9505f6b2e2b7738eeb3c22e94c45e6297fbdae66626febb0dbfe28c5050", size = 44288129 },
-    { url = "https://files.pythonhosted.org/packages/37/ac/1aca7e44c93876dbda00e80f79c0bda78bc65e236c68ceb2fc6b26f77df5/xformers-0.0.29.post2-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:0d0eb14db56cf08ec3fb9cb36ed5e98de1303411571539ca4dc080c5861e2744", size = 44289739 },
-]
-
-[[package]]
 name = "xgrammar"
-version = "0.1.18"
+version = "0.1.19"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ninja", marker = "sys_platform == 'linux'" },
@@ -3350,10 +2677,10 @@ dependencies = [
     { name = "transformers", marker = "sys_platform == 'linux'" },
     { name = "triton", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8f/c3/22c9eeab6ee1dd6d0513d227e9d307fd20a0491db58f1f04bc5d566d13dc/xgrammar-0.1.18.tar.gz", hash = "sha256:a0438a0f9262fff1d0e4f184268eb759f094243edce92b67eb7aa5f245c47471", size = 1697230 }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/55/73e1e4f918ade656c4fa7f3a5fcfb3d521a429fe305d2cb8ca58bfb201d4/xgrammar-0.1.19.tar.gz", hash = "sha256:75bf3e814283b1cbaee9252234c5d4081f0058d29b26d8984f1cdf031c99b775", size = 1714056 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/56/73/ba7bd8db631d3bbf224599d32587a2b94c4b4c539c47aa7b0ee2f8764d72/xgrammar-0.1.18-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:11512dd0f9000dd879b6f5dd222e1105ffc641b8b83d5949ef6550e41e2d84ce", size = 4824156 },
-    { url = "https://files.pythonhosted.org/packages/8f/c3/54acf006969aae4b0f3760998f0a9695fa4cadb5044e783ee9af40a1d2cc/xgrammar-0.1.18-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0ac7ef1f74af7bedc6cf992b4f9f5ea6f5a736ce17a3abb229108a3538e92000", size = 4825327 },
+    { url = "https://files.pythonhosted.org/packages/9d/47/77a6b826ff810094d059fc056393e61503beb0dfa6c53a0b27649df80ff1/xgrammar-0.1.19-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:78f02e241a2e6ec568b29da7ce049f350e2e95d2c51c5423c016b02f92941c63", size = 5831522 },
+    { url = "https://files.pythonhosted.org/packages/c6/68/df91740b23287d06c9d67fadd5d0dc096bb1beaf6079ab083f143545f520/xgrammar-0.1.19-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c9beb2cb2b55c9524f24b3cbf8181c47e435586976aa0c37e220661f786c601f", size = 5834560 },
 ]
 
 [[package]]
@@ -3454,13 +2781,4 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/25/722e3b93bd687009afb2d59a35e13d30ddd8f80571445bb0c4e4ce26ec66/yarl-1.24.2-cp312-cp312-win_amd64.whl", hash = "sha256:7dafe10c12ddd4d120d528c4b5599c953bd7b12845347d507b95451195bb6cad", size = 92901 },
     { url = "https://files.pythonhosted.org/packages/39/47/4486ccfb674c04854a1ef8aa77868b6a6f765feaf69633409d7ca4f02cb8/yarl-1.24.2-cp312-cp312-win_arm64.whl", hash = "sha256:044a09d8401fcf8681977faef6d286b8ade1e2d2e9dceda175d1cfa5ca496f30", size = 87229 },
     { url = "https://files.pythonhosted.org/packages/fd/4d/4b880086bd0d3e034d25647be1d830afc3e3f610e98c4ab3490af6b1b6d5/yarl-1.24.2-py3-none-any.whl", hash = "sha256:2783d9226db8797636cd6896e4de81feed252d1db72265686c9558d97a4d94b9", size = 53576 },
-]
-
-[[package]]
-name = "zipp"
-version = "4.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b9/d8/eab98a517c14134c0b2eb4e2387bc5f457334293ec5d2dd3857ec2966802/zipp-4.1.0.tar.gz", hash = "sha256:4cb57381f544315db7688e976e922a2b18cdb513d21cc194eb42232ba2a3e602", size = 26214 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/13/547360d81e6d88d58492968ffda9f9542854f11310ee556fef14260cc886/zipp-4.1.0-py3-none-any.whl", hash = "sha256:25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f", size = 10238 },
 ]


### PR DESCRIPTION
## Summary
- add Modal/SGLang launch, monitoring, and W&B credential wrapper scripts for baseline GSM8K GRPO
- wire SGLang rollout generation, frozen-reference KL support, checkpointing/memory mitigations, and configurable weight-sync interval
- add bounded completion logging, launch reports, and focused regression tests

## Verification
- `PYTHONPYCACHEPREFIX=/private/tmp/curious-pycache python3 -m py_compile curious/config.py curious/train/training_setup.py curious/train/trainer.py`
- `bash -n scripts/launch_baseline_gsm8k_grpo_modal.sh`
- `zsh scripts/run_baseline_gsm8k_training.sh --dry-run`
- focused pytest was attempted, but local collection is blocked by Homebrew `omegaconf`/ANTLR dependency mismatch; `.venv` does not have pytest installed

Note: left untracked `resesarch_proposal/` out of this PR because it appears to be older generated proposal output.